### PR TITLE
hawkmoth/parser: Display parser warnings and errors

### DIFF
--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -19,6 +19,7 @@ from docutils.parsers.rst import directives, Directive
 from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.util.docutils import switch_source_input
+from sphinx.util import logging
 
 from hawkmoth.parser import parse
 
@@ -30,6 +31,7 @@ class CAutoDocDirective(Directive):
     """Extract all documentation comments from the specified file"""
     required_argument = 1
     optional_arguments = 1
+    logger = logging.getLogger(__name__)
 
     # Allow passing a variable number of file patterns as arguments
     final_argument_whitespace = True
@@ -65,16 +67,16 @@ class CAutoDocDirective(Directive):
             filenames = glob.glob(env.config.cautodoc_root + '/' + pattern)
             if len(filenames) == 0:
                 fmt = 'Pattern "{pat}" does not match any files.'
-                env.app.warn(fmt.format(pat=pattern),
-                             location=(env.docname, self.lineno))
+                self.logger.warning(fmt.format(pat=pattern),
+                                    location=(env.docname, self.lineno))
                 continue
 
             for filename in filenames:
                 mode = os.stat(filename).st_mode
                 if stat.S_ISDIR(mode):
                     fmt = 'Path "{name}" matching pattern "{pat}" is a directory.'
-                    env.app.warn(fmt.format(name=filename, pat=pattern),
-                                 location=(env.docname, self.lineno))
+                    self.logger.warning(fmt.format(name=filename, pat=pattern),
+                                        location=(env.docname, self.lineno))
                     continue
 
                 # Tell Sphinx about the dependency and parse the file

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -31,8 +31,13 @@ def main():
                         help='Verbose output.')
     args = parser.parse_args()
 
-    comments = parse_to_string(args.file, args.verbose,
-                               compat=args.compat, clang=args.clang)
+    comments, errors = parse_to_string(args.file, args.verbose,
+                                        compat=args.compat, clang=args.clang)
+    if errors:
+        for diag in errors:
+            severity, filename = diag[0], diag[1]
+            lineno, reason = diag[2], diag[3]
+            sys.stderr.write("{}:{}, {}\n".format(filename, lineno, reason))
     sys.stdout.write(comments)
 
 main()

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -9,7 +9,9 @@ import testenv
 from hawkmoth.parser import parse_to_string
 
 def _get_output(input_filename, **options):
-    return parse_to_string(input_filename, False, **options)
+    output, errors = parse_to_string(input_filename, False, **options)
+    # FIXME: should handle errors
+    return output
 
 def _get_expected(input_filename, **options):
     return testenv.read_file(input_filename, ext='rst')


### PR DESCRIPTION
This patch prints out warnings, errors and fatal messages from clang
python bindings. Allows to trouble shooting to happen much faster
(i.e. missing include directories when resolving symbols)

Signed-off-by: Marius Vlad <marius.vlad@collabora.com>