### PR TITLE
hawkmoth: Display function attributes

### DIFF
--- a/hawkmoth/util/docstr.py
+++ b/hawkmoth/util/docstr.py
@@ -35,7 +35,7 @@ _doc_fmt = {
     Type.MEMBER:     (1, '\n.. c:member:: {ttype} {name}\n\n{text}\n'),
     Type.MACRO:      (1, '\n.. c:macro:: {name}\n\n{text}\n'),
     Type.MACRO_FUNC: (1, '\n.. c:function:: {name}({args})\n\n{text}\n'),
-    Type.FUNC:       (1, '\n.. c:function:: {ttype} {name}({args})\n\n{text}\n')
+    Type.FUNC:       (1, '\n.. c:function:: {ttype} {name}({args})\n\n{text}\n{attr}')
 }
 
 def _strip(comment):
@@ -67,8 +67,22 @@ def nest(text, nest):
     """
     return re.sub('(?m)^(?!$)', '   ' * nest, text)
 
+# injects reST
+def generate_attributes(attributes):
+    attrs = ''
+    if attributes is not None:
+        for attr in attributes:
+            k = attr['Attribute']
+            if k:
+                # not all attributes have a value
+                if 'Value' in attr:
+                    attrs += '\n**{}** {}\n'.format(k, attr['Value'])
+                else:
+                    attrs += '\n**{}**\n'.format(k)
+    return attrs
+
 def generate(text, fmt=Type.TEXT, name=None,
-             ttype=None, args=None, transform=None):
+             ttype=None, args=None, transform=None, attributes=None):
     """
     Generate reST documentation string.
 
@@ -96,6 +110,8 @@ def generate(text, fmt=Type.TEXT, name=None,
     if args is not None:
         args = ', '.join(args)
 
+    attrs = generate_attributes(attributes)
+
     (text_indent, fmt) = _doc_fmt[fmt]
     text = nest(text, text_indent)
-    return fmt.format(text=text, name=name, ttype=ttype, args=args)
+    return fmt.format(text=text, name=name, ttype=ttype, args=args, attr=attrs)

--- a/test/example-71-function-attrs.c
+++ b/test/example-71-function-attrs.c
@@ -1,0 +1,21 @@
+/**
+ * List frobnicator with pure attribute.
+ *
+ * :param list: The list to frob.
+ * :param mode: The frobnication mode.
+ * :return: 0 on success, non-zero error code on error.
+ * :since: v0.1
+ */
+__attribute__((pure))
+int pure_frob(struct list *list, enum mode mode);
+
+/**
+ * List frobnicator with const attribute
+ *
+ * :param list: The list to frob.
+ * :param mode: The frobnication mode.
+ * :return: 0 on success, non-zero error code on error.
+ * :since: v0.1
+ */
+__attribute__((const))
+int const_frob(struct list *list, enum mode mode);

--- a/test/example-71-function-attrs.rst
+++ b/test/example-71-function-attrs.rst
@@ -1,0 +1,24 @@
+
+.. c:function:: int pure_frob(struct list * list, enum mode mode)
+
+   List frobnicator with pure attribute.
+
+   :param list: The list to frob.
+   :param mode: The frobnication mode.
+   :return: 0 on success, non-zero error code on error.
+   :since: v0.1
+
+**Pure**
+
+
+.. c:function:: int const_frob(struct list * list, enum mode mode)
+
+   List frobnicator with const attribute
+
+   :param list: The list to frob.
+   :param mode: The frobnication mode.
+   :return: 0 on success, non-zero error code on error.
+   :since: v0.1
+
+**Const**
+

--- a/test/example-72-function-attrs-with-macros.c
+++ b/test/example-72-function-attrs-with-macros.c
@@ -1,0 +1,24 @@
+#define EXPORT_DEFAULT __attribute__ ((visibility("default")))
+#define EXPORT_HIDEN __attribute__ ((visibility("hidden")))
+
+/**
+ * List frobnicator with visibility hidden attribute.
+ *
+ * :param list: The list to frob.
+ * :param mode: The frobnication mode.
+ * :return: 0 on success, non-zero error code on error.
+ * :since: v0.1
+ */
+EXPORT_HIDEN
+int hidden_frob(struct list *list, enum mode mode);
+
+/**
+ * List frobnicator with visibility default attribute.
+ *
+ * :param list: The list to frob.
+ * :param mode: The frobnication mode.
+ * :return: 0 on success, non-zero error code on error.
+ * :since: v0.1
+ */
+EXPORT_DEFAULT
+int default_frob(struct list *list, enum mode mode);

--- a/test/example-72-function-attrs-with-macros.rst
+++ b/test/example-72-function-attrs-with-macros.rst
@@ -1,0 +1,24 @@
+
+.. c:function:: int hidden_frob(struct list * list, enum mode mode)
+
+   List frobnicator with visibility hidden attribute.
+
+   :param list: The list to frob.
+   :param mode: The frobnication mode.
+   :return: 0 on success, non-zero error code on error.
+   :since: v0.1
+
+**Visibility** hidden
+
+
+.. c:function:: int default_frob(struct list * list, enum mode mode)
+
+   List frobnicator with visibility default attribute.
+
+   :param list: The list to frob.
+   :param mode: The frobnication mode.
+   :return: 0 on success, non-zero error code on error.
+   :since: v0.1
+
+**Visibility** default
+


### PR DESCRIPTION
This adds some common attributes (like const, pure, and visibility).
Without this we have no way of knowing if the functions have such
attributes.

Signed-off-by: Marius Vlad <marius.vlad@collabora.com>