### PR TITLE
Add way of raising error messages from the parser

### DIFF
--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -46,7 +46,10 @@ class CAutoDocDirective(Directive):
         compat = self.options.get('compat', env.config.cautodoc_compat)
         clang = self.options.get('clang', env.config.cautodoc_clang)
 
-        comments = parse(filename, compat=compat, clang=clang)
+        comments, errors = parse(filename, compat=compat, clang=clang)
+
+        for (ffile, line, msg) in errors:
+            env.app.warn(_err_fmt.format(msg, location=(ffile, line)))
 
         for (comment, meta) in comments:
             lineoffset = meta['line'] - 1

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -239,6 +239,15 @@ def _recursive_parse(comments, cursor, nest, compat):
 
     return [(doc, meta)]
 
+def _clang_diagnostics(tu):
+    errors = []
+    for d in tu.diagnostics:
+        # Filter for warnings and errors
+        if d.severity >= 2:
+            errors.extend([(d.location.file.name, d.location.line, d.spelling)])
+
+    return errors
+
 # return a list of (comment, metadata) tuples
 # options - dictionary with directive options
 def parse(filename, **options):
@@ -255,6 +264,8 @@ def parse(filename, **options):
                      TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
                      TranslationUnit.PARSE_SKIP_FUNCTION_BODIES)
 
+    errors = _clang_diagnostics(tu)
+
     top_level_comments, comments = comment_extract(tu)
 
     result = []
@@ -270,7 +281,7 @@ def parse(filename, **options):
     # Sort all elements by order of appearance.
     result.sort(key=lambda r: r[1]['line'])
 
-    return result
+    return result, errors
 
 def parse_to_string(filename, verbose, **options):
     s = ''


### PR DESCRIPTION
This follows the current pattern used for passing the actual parsed
results except in a separate tuple. Currently it adds only diagnostics
from Clang, but the same concept can be extended to pass other warnings
or errors (e.g.) when we find weird documentation so we prod the user in
the right direction.

Original concept: Marius Vlad