### PR TITLE
Standardize newlines to be able to run test on windows machines

### DIFF
--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -277,8 +277,15 @@ def parse(filename, **options):
 
     index = Index.create()
 
-    tu = index.parse(filename, args=args, options=
-                     TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
+    # In order to let python standardize line endings across operating systems
+    # by reading in the file contents and sending that to libclang as an
+    # `unsaved_file`.
+    with open(filename, 'r') as f:
+        contents = f.read()
+        unsaved_files = [(filename, contents)]
+
+    tu = index.parse(filename, args=args, unsaved_files=unsaved_files,
+                     options=TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
                      TranslationUnit.PARSE_SKIP_FUNCTION_BODIES)
 
     clang_diagnostics(errors, tu.diagnostics)

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -277,15 +277,8 @@ def parse(filename, **options):
 
     index = Index.create()
 
-    # In order to let python standardize line endings across operating systems
-    # by reading in the file contents and sending that to libclang as an
-    # `unsaved_file`.
-    with open(filename, 'r') as f:
-        contents = f.read()
-        unsaved_files = [(filename, contents)]
-
-    tu = index.parse(filename, args=args, unsaved_files=unsaved_files,
-                     options=TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
+    tu = index.parse(filename, args=args, options=
+                     TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
                      TranslationUnit.PARSE_SKIP_FUNCTION_BODIES)
 
     clang_diagnostics(errors, tu.diagnostics)

--- a/hawkmoth/util/docstr.py
+++ b/hawkmoth/util/docstr.py
@@ -45,6 +45,10 @@ def _strip(comment):
     # Could look at first line of comment, and remove the leading stuff there
     # from the rest.
     comment = re.sub(r'(?m)^[ \t]*\*?[ \t]?', '', comment)
+
+    # Standardize newlines
+    comment = comment.replace('\r\n', '\n')
+
     # Strip leading blank lines.
     comment = re.sub(r'^[\n]*', '', comment)
     return comment.strip()


### PR DESCRIPTION
This was only proposed in the mailing list and I know there may still be discussion on whether this is the best/correct way to handle newlines across OS's.

P.S. The other test failures I had mentioned in the mailing list was git/windows/symlinks and those have been addressed at the user level.
