### PR TITLE
util: add helper for setting up libclang on readthedocs

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -87,3 +87,32 @@ look at the ``Dockerfile`` in the `Hawkmoth source repository`_ for a starting
 point; the file is used for testing during Hawkmoth development.
 
 .. _Hawkmoth source repository: https://github.com/jnikula/hawkmoth
+
+Read the Docs
+-------------
+
+It's possible to set up Hawkmoth based documentation on `Read the Docs`_ (RTD),
+and Hawkmoth provides a helper for configuration. There's a caveat, though: This
+is not based on the official RTD documentation, and might cease to work at any
+time.
+
+First, add a ``requirements.txt`` file to your project according to RTD
+`dependency documentation`_ to have RTD install some required dependencies::
+
+  clang>=6
+  hawkmoth>=0.7
+
+Next, add this snippet to your ``conf.py``:
+
+.. code-block:: python
+
+   from hawkmoth.util import readthedocs
+
+   readthedocs.clang_setup()
+
+This will try to find ``libclang`` on RTD, and configure Clang Python Bindings
+to use it.
+
+.. _Read the Docs: https://readthedocs.org/
+
+.. _dependency documentation: https://docs.readthedocs.io/en/stable/guides/specifying-dependencies.html

--- a/hawkmoth/util/readthedocs.py
+++ b/hawkmoth/util/readthedocs.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2021, Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+"""
+Read the Docs Helpers
+=====================
+
+Helpers for setting up and using Hawkmoth on Read the Docs.
+"""
+
+import os
+import subprocess
+
+def clang_setup(force=False):
+    """Try to find and configure libclang location on RTD."""
+    if 'READTHEDOCS' in os.environ or force:
+        try:
+            result = subprocess.run(['llvm-config', '--libdir'],
+                                    check=True, capture_output=True, encoding='utf-8')
+            libdir = result.stdout.strip()
+
+            # For some reason there is no plain libclang.so symlink on RTD.
+            from clang.cindex import Config
+            Config.set_library_file(os.path.join(libdir, 'libclang.so.1'))
+        except Exception as e:
+            print(e)


### PR DESCRIPTION
There's a bit of a chicken-and-egg problem for testing this, as RTD would install hawkmoth from pypi, which does not have the change... Also the required version in the documentation is set as >=0.7 which is unreleased. However I tested this with a dummy project with the function copied over:

https://github.com/jnikula/curly-octo-tribble
https://curly-octo-tribble.readthedocs.io/en/latest/

(curly-octo-tribble was a random name github suggested :)
