### PR TITLE
Transformations RFC

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -49,6 +49,13 @@ try:
     import hawkmoth
     extensions.append('hawkmoth')
     tags.add('have_hawkmoth')
+
+    from hawkmoth.util import doccompat
+    cautodoc_transformations = {
+        'javadoc-basic': doccompat.javadoc,
+        'javadoc-liberal': doccompat.javadoc_liberal,
+    }
+
 except ImportError:
     sys.stderr.write('Warning: Failed to import hawkmoth. Mocking results.\n')
     sys.path.insert(0, os.path.abspath('ext'))

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -48,6 +48,23 @@ The extension has a few configuration options that can be set in ``conf.py``:
       import os
       cautodoc_root = os.path.abspath('my/sources/dir')
 
+.. py:data:: cautodoc_transformations
+   :type: dict
+
+   Transformation options for the :data:`cautodoc_compat` option and the
+   :rst:dir:`c:autodoc` directive ``compat`` option. This is a dictionary that
+   maps names to functions. The functions are expected to take a (multi-line)
+   string as parameter and return the transformed string.
+
+   .. code-block:: python
+
+      from hawkmoth.util import doccompat
+      cautodoc_transformations = {
+          'javadoc-basic': doccompat.javadoc,
+          'javadoc-liberal': doccompat.javadoc_liberal,
+          'kernel-doc': doccompat.kerneldoc,
+      }
+
 .. py:data:: cautodoc_compat
    :type: str
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -22,6 +22,7 @@ from sphinx.util.docutils import switch_source_input
 from sphinx.util import logging
 
 from hawkmoth.parser import parse, ErrorLevel
+from hawkmoth.util import doccompat
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
@@ -67,7 +68,9 @@ class CAutoDocDirective(Directive):
         compat = self.options.get('compat', env.config.cautodoc_compat)
         clang = self.options.get('clang', env.config.cautodoc_clang)
 
-        comments, errors = parse(filename, compat=compat, clang=clang)
+        transform = lambda x: doccompat.convert(x, compat)
+
+        comments, errors = parse(filename, transform=transform, clang=clang)
 
         self.__display_parser_diagnostics(errors)
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -68,7 +68,7 @@ class CAutoDocDirective(Directive):
         compat = self.options.get('compat', env.config.cautodoc_compat)
         clang = self.options.get('clang', env.config.cautodoc_clang)
 
-        transform = lambda x: doccompat.convert(x, compat)
+        transform = lambda x: doccompat.convert(x, mode=compat)
 
         comments, errors = parse(filename, transform=transform, clang=clang)
 

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -24,7 +24,8 @@ def main():
                         choices=['none',
                                  'javadoc-basic',
                                  'javadoc-liberal',
-                                 'kernel-doc'],
+                                 'kernel-doc',
+                                 'napoleon'],
                         help='Compatibility options. See cautodoc_compat.')
     parser.add_argument('--clang', metavar='PARAM[,PARAM,...]',
                         help='Arguments to pass to clang. See cautodoc_clang.')

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -11,6 +11,7 @@ import argparse
 import sys
 
 from hawkmoth.parser import parse
+from hawkmoth.util import doccompat
 
 def main():
     parser = argparse.ArgumentParser(prog='hawkmoth', description="""
@@ -31,7 +32,9 @@ def main():
                         help='Verbose output.')
     args = parser.parse_args()
 
-    docs, errors = parse(args.file, compat=args.compat, clang=args.clang)
+    transform = lambda x: doccompat.convert(x, args.compat)
+
+    docs, errors = parse(args.file, transform=transform, clang=args.clang)
 
     for (doc, meta) in docs:
         if args.verbose:

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -32,7 +32,7 @@ def main():
                         help='Verbose output.')
     args = parser.parse_args()
 
-    transform = lambda x: doccompat.convert(x, args.compat)
+    transform = lambda x: doccompat.convert(x, mode=args.compat)
 
     docs, errors = parse(args.file, transform=transform, clang=args.clang)
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -42,7 +42,7 @@ from clang.cindex import Index, TranslationUnit
 from clang.cindex import SourceLocation, SourceRange
 from clang.cindex import TokenKind, TokenGroup
 
-from hawkmoth.util import docstr, doccompat
+from hawkmoth.util import docstr
 
 class ErrorLevel(enum.Enum):
     """
@@ -311,7 +311,7 @@ def parse(filename, **options):
     top_level_comments, comments = comment_extract(tu)
 
     result = []
-    transform = lambda x: doccompat.convert(x, options.get('compat'))
+    transform = options.get('transform')
 
     for comment in top_level_comments:
         result.extend(_result(comment, transform=transform))

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -104,14 +104,14 @@ def comment_extract(tu):
     return top_level_comments, comments
 
 def _result(comment, cursor=None, fmt=docstr.Type.TEXT, nest=0,
-            name=None, ttype=None, args=None, compat=None):
+            name=None, ttype=None, args=None, transform=None):
 
     # FIXME: docstr.generate changes the number of lines in output. This impacts
     # the error reporting via meta['line']. Adjust meta to take this into
     # account.
 
     doc = docstr.generate(text=comment.spelling, fmt=fmt,
-                          name=name, ttype=ttype, args=args, transform=compat)
+                          name=name, ttype=ttype, args=args, transform=transform)
 
     doc = docstr.nest(doc, nest)
 
@@ -154,7 +154,7 @@ def _get_macro_args(cursor):
 
     return None
 
-def _recursive_parse(comments, cursor, nest, compat):
+def _recursive_parse(comments, cursor, nest, transform):
     comment = comments[cursor.hash]
     name = cursor.spelling
     ttype = cursor.type.spelling
@@ -165,7 +165,7 @@ def _recursive_parse(comments, cursor, nest, compat):
         fmt = docstr.Type.MACRO if args is None else docstr.Type.MACRO_FUNC
 
         return _result(comment, cursor=cursor, fmt=fmt,
-                       nest=nest, name=name, args=args, compat=compat)
+                       nest=nest, name=name, args=args, transform=transform)
 
     elif cursor.kind in [CursorKind.VAR_DECL, CursorKind.FIELD_DECL]:
         if cursor.kind == CursorKind.VAR_DECL:
@@ -189,14 +189,14 @@ def _recursive_parse(comments, cursor, nest, compat):
             ttype = ''
 
         return _result(comment, cursor=cursor, fmt=fmt,
-                       nest=nest, name=name, ttype=ttype, compat=compat)
+                       nest=nest, name=name, ttype=ttype, transform=transform)
 
     elif cursor.kind == CursorKind.TYPEDEF_DECL:
         # FIXME: function pointers typedefs.
         fmt = docstr.Type.TYPE
 
         return _result(comment, cursor=cursor, fmt=fmt,
-                       nest=nest, name=ttype, compat=compat)
+                       nest=nest, name=ttype, transform=transform)
 
     elif cursor.kind in [CursorKind.STRUCT_DECL, CursorKind.UNION_DECL,
                          CursorKind.ENUM_DECL]:
@@ -220,12 +220,12 @@ def _recursive_parse(comments, cursor, nest, compat):
 
         # name may be empty for typedefs
         result = _result(comment, cursor=cursor, fmt=fmt,
-                         nest=nest, name=name if name else ttype, compat=compat)
+                         nest=nest, name=name if name else ttype, transform=transform)
 
         nest += 1
         for c in cursor.get_children():
             if c.hash in comments:
-                result.extend(_recursive_parse(comments, c, nest, compat))
+                result.extend(_recursive_parse(comments, c, nest, transform))
 
         return result
 
@@ -233,7 +233,7 @@ def _recursive_parse(comments, cursor, nest, compat):
         fmt = docstr.Type.ENUM_VAL
 
         return _result(comment, cursor=cursor, fmt=fmt,
-                       nest=nest, name=name, compat=compat)
+                       nest=nest, name=name, transform=transform)
 
     elif cursor.kind == CursorKind.FUNCTION_DECL:
         # FIXME: check args against comment
@@ -255,7 +255,7 @@ def _recursive_parse(comments, cursor, nest, compat):
         ttype = cursor.result_type.spelling
 
         return _result(comment, cursor=cursor, fmt=fmt, nest=nest,
-                       name=name, ttype=ttype, args=args, compat=compat)
+                       name=name, ttype=ttype, args=args, transform=transform)
 
     # FIXME: If we reach here, nothing matched. This is a warning or even error
     # and it should be logged, but it should also return an empty list so that
@@ -311,14 +311,14 @@ def parse(filename, **options):
     top_level_comments, comments = comment_extract(tu)
 
     result = []
-    compat = lambda x: doccompat.convert(x, options.get('compat'))
+    transform = lambda x: doccompat.convert(x, options.get('compat'))
 
     for comment in top_level_comments:
-        result.extend(_result(comment, compat=compat))
+        result.extend(_result(comment, transform=transform))
 
     for cursor in tu.cursor.get_children():
         if cursor.hash in comments:
-            result.extend(_recursive_parse(comments, cursor, 0, compat))
+            result.extend(_recursive_parse(comments, cursor, 0, transform))
 
     # Sort all elements by order of appearance.
     result.sort(key=lambda r: r[1]['line'])

--- a/hawkmoth/util/doccompat.py
+++ b/hawkmoth/util/doccompat.py
@@ -17,9 +17,11 @@ import re
 # facilitate any kind of migration to Hawkmoth. The compat code could be turned
 # into a fairly simple plugin architecture, with some basic compat builtins, and
 # the users could still extend the compat features to fit their specific needs.
-def convert(comment, mode):
+def convert(comment, **options):
     """Convert documentation from a supported syntax into reST."""
     # FIXME: try to preserve whitespace better
+
+    mode = options.get('mode')
 
     if mode == 'javadoc-basic' or mode == 'javadoc-liberal':
         # @param

--- a/hawkmoth/util/doccompat.py
+++ b/hawkmoth/util/doccompat.py
@@ -21,6 +21,12 @@ import re
 # FIXME: try to preserve whitespace better
 #
 
+from sphinx.ext.napoleon import docstring, Config
+
+def napo(comment, **options):
+    config = Config(napoleon_use_rtype=False)
+    return str(docstring.GoogleDocstring(comment, config))
+
 def javadoc(comment, **options):
     """Basic javadoc conversion to reStructuredText"""
 
@@ -79,6 +85,7 @@ def convert(comment, **options):
         'javadoc-basic': javadoc,
         'javadoc-liberal': javadoc_liberal,
         'kernel-doc': kerneldoc,
+        'napoleon': napo,
     }
 
     if mode in transformations:

--- a/hawkmoth/util/doccompat.py
+++ b/hawkmoth/util/doccompat.py
@@ -17,46 +17,71 @@ import re
 # facilitate any kind of migration to Hawkmoth. The compat code could be turned
 # into a fairly simple plugin architecture, with some basic compat builtins, and
 # the users could still extend the compat features to fit their specific needs.
+#
+# FIXME: try to preserve whitespace better
+#
+
+def javadoc(comment, **options):
+    """Basic javadoc conversion to reStructuredText"""
+
+    # @param
+    comment = re.sub(r"(?m)^([ \t]*)@param([ \t]+)([a-zA-Z0-9_]+|\.\.\.)([ \t]+)",
+                     "\n\\1:param\\2\\3:\\4", comment)
+    # @param[direction]
+    comment = re.sub(r"(?m)^([ \t]*)@param\[([^]]*)\]([ \t]+)([a-zA-Z0-9_]+|\.\.\.)([ \t]+)",
+                     "\n\\1:param\\3\\4: *(\\2)* \\5", comment)
+    # @return
+    comment = re.sub(r"(?m)^([ \t]*)@returns?([ \t]+|$)",
+                     "\n\\1:return:\\2", comment)
+    # @code/@endcode blocks. Works if the code is indented.
+    comment = re.sub(r"(?m)^([ \t]*)@code([ \t]+|$)",
+                     "\n::\n", comment)
+    comment = re.sub(r"(?m)^([ \t]*)@endcode([ \t]+|$)",
+                     "\n", comment)
+    # Ignore @brief.
+    comment = re.sub(r"(?m)^([ \t]*)@brief[ \t]+", "\n\\1", comment)
+
+    # Ignore groups
+    comment = re.sub(r"(?m)^([ \t]*)@(defgroup|addtogroup)[ \t]+[a-zA-Z0-9_]+[ \t]*",
+                     "\n\\1", comment)
+    comment = re.sub(r"(?m)^([ \t]*)@(ingroup|{|}).*", "\n", comment)
+
+    return comment
+
+def javadoc_liberal(comment, **options):
+    """Liberal javadoc conversion to reStructuredText"""
+
+    comment = javadoc(comment)
+
+    # Liberal conversion of any @tags, will fail for @code etc. but don't
+    # care.
+    comment = re.sub(r"(?m)^([ \t]*)@([a-zA-Z0-9_]+)([ \t]+)",
+                     "\n\\1:\\2:\\3", comment)
+
+    return comment
+
+def kerneldoc(comment, **options):
+    """Basic kernel-doc conversion to reStructuredText"""
+
+    comment = re.sub(r"(?m)^([ \t]*)@(returns?|RETURNS?):([ \t]+|$)",
+                     "\n\\1:return:\\3", comment)
+    comment = re.sub(r"(?m)^([ \t]*)@([a-zA-Z0-9_]+|\.\.\.):([ \t]+)",
+                     "\n\\1:param \\2:\\3", comment)
+
+    return comment
+
 def convert(comment, **options):
     """Convert documentation from a supported syntax into reST."""
-    # FIXME: try to preserve whitespace better
 
     mode = options.get('mode')
 
-    if mode == 'javadoc-basic' or mode == 'javadoc-liberal':
-        # @param
-        comment = re.sub(r"(?m)^([ \t]*)@param([ \t]+)([a-zA-Z0-9_]+|\.\.\.)([ \t]+)",
-                         "\n\\1:param\\2\\3:\\4", comment)
-        # @param[direction]
-        comment = re.sub(r"(?m)^([ \t]*)@param\[([^]]*)\]([ \t]+)([a-zA-Z0-9_]+|\.\.\.)([ \t]+)",
-                         "\n\\1:param\\3\\4: *(\\2)* \\5", comment)
-        # @return
-        comment = re.sub(r"(?m)^([ \t]*)@returns?([ \t]+|$)",
-                         "\n\\1:return:\\2", comment)
-        # @code/@endcode blocks. Works if the code is indented.
-        comment = re.sub(r"(?m)^([ \t]*)@code([ \t]+|$)",
-                         "\n::\n", comment)
-        comment = re.sub(r"(?m)^([ \t]*)@endcode([ \t]+|$)",
-                         "\n", comment)
-        # Ignore @brief.
-        comment = re.sub(r"(?m)^([ \t]*)@brief[ \t]+", "\n\\1", comment)
+    transformations = {
+        'javadoc-basic': javadoc,
+        'javadoc-liberal': javadoc_liberal,
+        'kernel-doc': kerneldoc,
+    }
 
-        # Ignore groups
-        comment = re.sub(r"(?m)^([ \t]*)@(defgroup|addtogroup)[ \t]+[a-zA-Z0-9_]+[ \t]*",
-                         "\n\\1", comment)
-        comment = re.sub(r"(?m)^([ \t]*)@(ingroup|{|}).*", "\n", comment)
-
-    if mode == 'javadoc-liberal':
-        # Liberal conversion of any @tags, will fail for @code etc. but don't
-        # care.
-        comment = re.sub(r"(?m)^([ \t]*)@([a-zA-Z0-9_]+)([ \t]+)",
-                         "\n\\1:\\2:\\3", comment)
-
-    if mode == 'kernel-doc':
-        # Basic kernel-doc convert, will document struct members as params, etc.
-        comment = re.sub(r"(?m)^([ \t]*)@(returns?|RETURNS?):([ \t]+|$)",
-                         "\n\\1:return:\\3", comment)
-        comment = re.sub(r"(?m)^([ \t]*)@([a-zA-Z0-9_]+|\.\.\.):([ \t]+)",
-                         "\n\\1:param \\2:\\3", comment)
+    if mode in transformations:
+        comment = transformations[mode](comment, **options)
 
     return comment

--- a/test/conf.py
+++ b/test/conf.py
@@ -42,6 +42,13 @@ extensions = [
     'hawkmoth'
 ]
 
+from hawkmoth.util import doccompat
+cautodoc_transformations = {
+    'javadoc-basic': doccompat.javadoc,
+    'javadoc-liberal': doccompat.javadoc_liberal,
+    'kernel-doc': doccompat.kerneldoc,
+}
+
 # Add any paths that contain templates here, relative to this directory.
 #templates_path = ['_templates']
 

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -7,10 +7,15 @@ import unittest
 
 import testenv
 from hawkmoth.parser import parse
+from hawkmoth.util import doccompat
 
 def _get_output(input_filename, **options):
     docs_str = ''
     errors_str = ''
+
+    compat = options.pop('compat', None)
+    if compat is not None:
+        options['transform'] = lambda x: doccompat.convert(x, compat)
 
     docs, errors = parse(input_filename, **options)
 

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -15,7 +15,7 @@ def _get_output(input_filename, **options):
 
     compat = options.pop('compat', None)
     if compat is not None:
-        options['transform'] = lambda x: doccompat.convert(x, compat)
+        options['transform'] = lambda x: doccompat.convert(x, mode=compat)
 
     docs, errors = parse(input_filename, **options)
 


### PR DESCRIPTION
Not intended for merging as-is, but here's some ideas of what to do with compat and transformations, hoping to get some feedback.

Basically, start deprecating "compat" and moving towards user-defined "transformations". The transformations can reuse the existing doccompat functions, extend them, support fully user-written transformations, etc.

There are probably enough users to warrant some level of backwards compatibility while deprecating compat. But long term I'd like Hawkmoth focus to be on basically passing through the comments from clang to sphinx with minimal C comment mark and indentation removal, with no extra conversion that can go wrong.
