### PR TITLE
RFC: Discover system include path

### DIFF
--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -67,6 +67,20 @@ The extension has a few configuration options that can be set in ``conf.py``:
    source, typically to define macros for conditional compilation, for example
    ``-DHAWKMOTH``. No arguments are passed by default.
 
+.. py:data:: cautodoc_cc_use_system_include_path
+   :type: bool
+
+   Try to use the compiler specified by :data:`cautodoc_cc_path` to figure out
+   the system include paths, and pass them as ``-I`` options for parsing the
+   source code comments. False by default.
+
+.. py:data:: cautodoc_cc_path
+   :type: str
+
+   Compiler to use for figuring out the system include paths if
+   :data:`cautodoc_cc_use_system_include_path` is enabled. This is not used for
+   parsing the source code comments. Defaults to ``clang``.
+
 Directive
 ---------
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -66,8 +66,12 @@ class CAutoDocDirective(Directive):
 
         compat = self.options.get('compat', env.config.cautodoc_compat)
         clang = self.options.get('clang', env.config.cautodoc_clang)
+        cc_path = env.config.cautodoc_cc_path
+        cc_use_system_include_path = env.config.cautodoc_cc_use_system_include_path
 
-        comments, errors = parse(filename, compat=compat, clang=clang)
+        comments, errors = parse(filename, compat=compat, clang=clang,
+                                 cc_path=cc_path,
+                                 cc_use_system_include_path=cc_use_system_include_path)
 
         self.__display_parser_diagnostics(errors)
 
@@ -116,6 +120,8 @@ def setup(app):
     app.add_config_value('cautodoc_root', app.confdir, 'env')
     app.add_config_value('cautodoc_compat', None, 'env')
     app.add_config_value('cautodoc_clang', None, 'env')
+    app.add_config_value('cautodoc_cc_path', 'clang', 'env')
+    app.add_config_value('cautodoc_cc_use_system_include_path', False, 'env')
     app.add_directive_to_domain('c', 'autodoc', CAutoDocDirective)
 
     return dict(version = __version__,

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -27,11 +27,15 @@ def main():
                         help='Compatibility options. See cautodoc_compat.')
     parser.add_argument('--clang', metavar='PARAM[,PARAM,...]',
                         help='Arguments to pass to clang. See cautodoc_clang.')
+    parser.add_argument('--cc-use-system-include-path', action='store_true')
+    parser.add_argument('--cc-path', type=str, default='clang')
     parser.add_argument('--verbose', dest='verbose', action='store_true',
                         help='Verbose output.')
     args = parser.parse_args()
 
-    docs, errors = parse(args.file, compat=args.compat, clang=args.clang)
+    docs, errors = parse(args.file, compat=args.compat, clang=args.clang,
+                         cc_use_system_include_path=args.cc_use_system_include_path,
+                         cc_path=args.cc_path)
 
     for (doc, meta) in docs:
         if args.verbose:

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -289,16 +289,22 @@ def clang_diagnostics(errors, diagnostics):
         errors.extend([(sev[diag.severity], filename,
                         diag.location.line, diag.spelling)])
 
+def _get_user_args(args, errors, **options):
+    user_args = options.get('clang')
+    if user_args is not None:
+        user_args = [s.strip() for s in user_args.split(',') if len(s.strip()) > 0]
+        args.extend(user_args)
+
 # return a list of (comment, metadata) tuples
 # options - dictionary with directive options
 def parse(filename, **options):
-
+    args = []
     errors = []
-    args = options.get('clang')
-    if args is not None:
-        args = [s.strip() for s in args.split(',') if len(s.strip()) > 0]
-        if len(args) == 0:
-            args = None
+
+    _get_user_args(args, errors, **options)
+
+    if len(args) == 0:
+        args = None
 
     index = Index.create()
 

--- a/hawkmoth/util/compiler.py
+++ b/hawkmoth/util/compiler.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2021 Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+"""
+Compiler helpers
+================
+
+This module provides helper functions to access compiler information outside of
+the Clang Python Bindings, for example system include paths.
+"""
+
+import subprocess
+
+def _removesuffix(s, suffix):
+    if suffix and s.endswith(suffix):
+        return s[:-len(suffix)]
+    else:
+        return s[:]
+
+def _get_paths_from_output(output):
+    started = False
+    for line in output.splitlines():
+        if not started:
+            if line == '#include <...> search starts here:':
+                started = True
+            continue
+
+        if line == 'End of search list.':
+            break
+
+        line = _removesuffix(line, '(framework directory)')
+
+        yield line.strip()
+
+def _get_include_paths(cc_path):
+    result = subprocess.run([cc_path, '-E', '-Wp,-v', '-'],
+                            stdin=subprocess.DEVNULL,
+                            capture_output=True,
+                            check=True,
+                            text=True)
+
+    return _get_paths_from_output(result.stderr)
+
+def get_include_args(cc_path):
+    return ['-I{path}'.format(path=path) for path in _get_include_paths(cc_path)]
+
+if __name__ == '__main__':
+    import pprint
+    import sys
+
+    cc_path = sys.argv[1] if len(sys.argv) > 1 else 'clang'
+
+    pprint.pprint(get_include_args(cc_path))


### PR DESCRIPTION
Fix for #29.

I've got mixed feelings about this.

On the one hand, it's an obvious, fairly isolated and straightforward thing to do. It should make Hawkmoth easier to use for real users out there. And I've written the code, it's there.

On the other hand, I clearly have a configuration where I can't reproduce the issues (I don't know why; maybe recent libclang already does this?), I have a hard time thinking of reasonable and portable test cases for this, and it also has a feeling of bloat beyond the KISS principle.

WRT design, perhaps this should be handled at one abstraction level higher than the parser. Since the parser is all about clang and its python bindings, and this uses the compiler front-end directly.