### PR TITLE
parser: fix function pointer parameters

### DIFF
--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -268,6 +268,7 @@ def _recursive_parse(comments, cursor, nest, compat):
             for c in cursor.get_children():
                 if c.kind == CursorKind.PARM_DECL:
                     arg_ttype, arg_name = _array_fixup(c.type.spelling, c.spelling)
+                    arg_ttype, arg_name = _function_pointer_fixup(arg_ttype, arg_name)
 
                     args.append('{ttype} {name}'.format(ttype=arg_ttype,
                                                         name=arg_name))

--- a/test/function.c
+++ b/test/function.c
@@ -24,3 +24,8 @@ void foorray(const double array[], int x[5]);
  * Clang removes spaces.
  */
 void multi_array_param(int x[2][2], int y [2] [2]);
+
+/**
+ * Function pointer parameter.
+ */
+void function_pointer_param(void* (*hook)(void *p, int n));

--- a/test/function.rst
+++ b/test/function.rst
@@ -25,3 +25,8 @@
 
    Clang removes spaces.
 
+
+.. c:function:: void function_pointer_param( void *(*hook)(void *, int))
+
+   Function pointer parameter.
+


### PR DESCRIPTION
Use _function_pointer_fixup() also for function parameters.

This leaves a superfluous space in the output similar to function
pointer variables and struct members. Postpone fixing that to handling
all of these together instead of adding a local fix here.

Fixes: #41