### PR TITLE
Test switch to pytest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ Dependencies
 - Sphinx 3
 - Clang 6.0
 - Python 3 Bindings for Clang 6.0
+- pytest (for development)
 - sphinx-testing 1.0.0 (for development)
 
 These are the versions Hawkmoth is currently being developed and tested

--- a/requirements-latest.txt
+++ b/requirements-latest.txt
@@ -1,2 +1,3 @@
+pytest
 sphinx
 sphinx-testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,20 @@
 alabaster==0.7.12
+attrs==20.3.0
 Babel==2.9.0
 certifi==2020.12.5
 chardet==4.0.0
 docutils==0.16
 idna==2.10
 imagesize==1.2.0
+iniconfig==1.1.1
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 packaging==20.9
+pluggy==0.13.1
+py==1.10.0
 Pygments==2.8.1
 pyparsing==2.4.7
+pytest==6.2.3
 pytz==2021.1
 requests==2.25.1
 six==1.15.0
@@ -22,4 +27,5 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
+toml==0.10.2
 urllib3==1.26.4

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
     ],
     extras_require = {
         'dev': [
+            'pytest',
             'sphinx-testing'
         ],
     },

--- a/test/Makefile.local
+++ b/test/Makefile.local
@@ -1,10 +1,6 @@
 # -*- makefile -*-
 # Copyright (c) 2017-2018, Jani Nikula <jani@nikula.org>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
-#
-# FIXME: This is inadequate. Needs more test data, in particular more
-# pathological real world test data.
-#
 
 test_dir := test
 

--- a/test/Makefile.local
+++ b/test/Makefile.local
@@ -10,4 +10,4 @@ test_dir := test
 
 .PHONY: test
 test:
-	python3 -m unittest discover -s $(test_dir)
+	pytest $(test_dir)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2021, Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+
+import pytest
+
+# Enable introspection on assertions in testenv
+pytest.register_assert_rewrite('test.testenv')

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -5,6 +5,7 @@
 import os
 import shutil
 
+import pytest
 from sphinx_testing import with_app
 
 from test import testenv
@@ -34,7 +35,7 @@ def _get_expected(input_filename, app, status, warning, **options):
 
     return testenv.read_file(os.path.join(app.outdir, 'index.txt')), None
 
-class TestDirective:
-    pass
-
-testenv.assign_test_methods(TestDirective, _get_output, _get_expected)
+@pytest.mark.parametrize('input_filename', testenv.get_testcases(testenv.testdir),
+                         ids=testenv.get_testid)
+def test_directive(input_filename):
+    testenv.run_test(input_filename, _get_output, _get_expected)

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -6,8 +6,9 @@ import os
 import shutil
 import unittest
 
-import testenv
 from sphinx_testing import with_app
+
+from test import testenv
 
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
 def _get_output(input_filename, app, status, warning, **options):

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -4,7 +4,6 @@
 
 import os
 import shutil
-import unittest
 
 from sphinx_testing import with_app
 
@@ -35,10 +34,7 @@ def _get_expected(input_filename, app, status, warning, **options):
 
     return testenv.read_file(os.path.join(app.outdir, 'index.txt')), None
 
-class DirectiveTest(unittest.TestCase):
+class TestDirective:
     pass
 
-testenv.assign_test_methods(DirectiveTest, _get_output, _get_expected)
-
-if __name__ == '__main__':
-    unittest.main()
+testenv.assign_test_methods(TestDirective, _get_output, _get_expected)

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -4,6 +4,8 @@
 
 import os
 
+import pytest
+
 from hawkmoth.parser import parse
 from test import testenv
 
@@ -25,7 +27,8 @@ def _get_expected(input_filename, **options):
     return testenv.read_file(input_filename, ext='rst'), \
         testenv.read_file(input_filename, ext='stderr')
 
-class TestParser:
-    pass
+@pytest.mark.parametrize('input_filename', testenv.get_testcases(testenv.testdir),
+                         ids=testenv.get_testid)
+def test_parser(input_filename):
+    testenv.run_test(input_filename, _get_output, _get_expected)
 
-testenv.assign_test_methods(TestParser, _get_output, _get_expected)

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -3,7 +3,6 @@
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 
 import os
-import unittest
 
 from hawkmoth.parser import parse
 from test import testenv
@@ -26,10 +25,7 @@ def _get_expected(input_filename, **options):
     return testenv.read_file(input_filename, ext='rst'), \
         testenv.read_file(input_filename, ext='stderr')
 
-class ParserTest(unittest.TestCase):
+class TestParser:
     pass
 
-testenv.assign_test_methods(ParserTest, _get_output, _get_expected)
-
-if __name__ == '__main__':
-    unittest.main()
+testenv.assign_test_methods(TestParser, _get_output, _get_expected)

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -5,8 +5,8 @@
 import os
 import unittest
 
-import testenv
 from hawkmoth.parser import parse
+from test import testenv
 
 def _get_output(input_filename, **options):
     docs_str = ''

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2018, Jani Nikula <jani@nikula.org>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 
-import sys
 import os
-import unittest
+import sys
+
+import pytest
 
 testext = '.c'
 testdir = os.path.dirname(os.path.abspath(__file__))
@@ -77,8 +78,8 @@ def _test_generator(get_output, get_expected, input_filename, **options):
         output_docs, output_errors = get_output(input_filename, **options)
         expect_docs, expect_errors = get_expected(input_filename, **options)
 
-        self.assertEqual(expect_docs, output_docs)
-        self.assertEqual(expect_errors, output_errors)
+        assert expect_docs == output_docs
+        assert expect_errors == output_errors
 
     return test
 
@@ -89,6 +90,6 @@ def assign_test_methods(cls, get_output, get_expected):
         method = _test_generator(get_output, get_expected, f, **options)
 
         if options.get('test-expected-failure') is not None:
-            method = unittest.expectedFailure(method)
+            method = pytest.mark.xfail(method)
 
         setattr(cls, _testcase_name(f), method)


### PR DESCRIPTION
Switch from unittest to pytest, although it adds another development dependency. The dynamic test parametrization gets cleaner.