### PR TITLE
System include path v2

### DIFF
--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -94,7 +94,7 @@ This module provides the following new directive:
    .. rst:directive:option:: clang
       :type: text
 
-      The ``clang`` option overrides the :data:`cautodoc_clang` configuration
+      The ``clang`` option extends the :data:`cautodoc_clang` configuration
       option.
 
 Examples

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -61,11 +61,18 @@ The extension has a few configuration options that can be set in ``conf.py``:
       are likely to change.
 
 .. py:data:: cautodoc_clang
-   :type: str
+   :type: list, str
 
-   A comma separated list of arguments to pass to ``clang`` while parsing the
-   source, typically to define macros for conditional compilation, for example
-   ``-DHAWKMOTH``. No arguments are passed by default.
+   A list of arguments to pass to ``clang`` while parsing the source, typically
+   to add directories to include file search path, or to define macros for
+   conditional compilation. May be specified as a Python list, or as a string
+   with arguments separated by commas. No arguments are passed by default.
+
+   Example:
+
+   .. code-block:: python
+
+      cautodoc_clang = ['-I/path/to/include', '-DHAWKMOTH' ]
 
 Directive
 ---------

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -74,6 +74,18 @@ The extension has a few configuration options that can be set in ``conf.py``:
 
       cautodoc_clang = ['-I/path/to/include', '-DHAWKMOTH' ]
 
+   Hawkmoth provides a convenience helper for querying the include path from the
+   compiler, and providing them as ``-I`` options:
+
+   .. code-block:: python
+
+      from hawkmoth.util import compiler
+
+      cautodoc_clang = compiler.get_include_args()
+
+   You can also pass in the compiler to use, for example
+   ``get_include_args('gcc')``.
+
 Directive
 ---------
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -22,6 +22,7 @@ from sphinx.util.docutils import switch_source_input
 from sphinx.util import logging
 
 from hawkmoth.parser import parse, ErrorLevel
+from hawkmoth.util import strutil
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
@@ -64,7 +65,9 @@ class CAutoDocDirective(Directive):
     def __get_clang_args(self):
         env = self.state.document.settings.env
 
-        clang_args = self.options.get('clang', env.config.cautodoc_clang)
+        clang_args = strutil.args_as_list(env.config.cautodoc_clang)
+
+        clang_args.extend(strutil.args_as_list(self.options.get('clang')))
 
         return clang_args
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -61,13 +61,20 @@ class CAutoDocDirective(Directive):
                 self.logger.log(self._log_lvl[severity], toprint,
                                 location=(env.docname, self.lineno))
 
+    def __get_clang_args(self):
+        env = self.state.document.settings.env
+
+        clang_args = self.options.get('clang', env.config.cautodoc_clang)
+
+        return clang_args
+
     def __parse(self, viewlist, filename):
         env = self.state.document.settings.env
 
         compat = self.options.get('compat', env.config.cautodoc_compat)
-        clang = self.options.get('clang', env.config.cautodoc_clang)
+        clang_args = self.__get_clang_args()
 
-        comments, errors = parse(filename, compat=compat, clang=clang)
+        comments, errors = parse(filename, compat=compat, clang=clang_args)
 
         self.__display_parser_diagnostics(errors)
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -320,10 +320,8 @@ def parse(filename, **options):
 
     errors = []
     args = options.get('clang')
-    if args is not None:
+    if isinstance(args, str):
         args = [s.strip() for s in args.split(',') if len(s.strip()) > 0]
-        if len(args) == 0:
-            args = None
 
     index = Index.create()
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -42,7 +42,7 @@ from clang.cindex import Index, TranslationUnit
 from clang.cindex import SourceLocation, SourceRange
 from clang.cindex import TokenKind, TokenGroup
 
-from hawkmoth.util import docstr, doccompat
+from hawkmoth.util import docstr, doccompat, strutil
 
 class ErrorLevel(enum.Enum):
     """
@@ -319,9 +319,7 @@ def clang_diagnostics(errors, diagnostics):
 def parse(filename, **options):
 
     errors = []
-    args = options.get('clang')
-    if isinstance(args, str):
-        args = [s.strip() for s in args.split(',') if len(s.strip()) > 0]
+    args = strutil.args_as_list(options.get('clang'))
 
     index = Index.create()
 

--- a/hawkmoth/util/compiler.py
+++ b/hawkmoth/util/compiler.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2021 Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+"""
+Compiler helpers
+================
+
+This module provides helper functions to access compiler information outside of
+the Clang Python Bindings, for example system include paths.
+"""
+
+import subprocess
+
+def _removesuffix(s, suffix):
+    if suffix and s.endswith(suffix):
+        return s[:-len(suffix)]
+    else:
+        return s[:]
+
+def _get_paths_from_output(output):
+    started = False
+    for line in output.splitlines():
+        if not started:
+            if line == '#include <...> search starts here:':
+                started = True
+            continue
+
+        if line == 'End of search list.':
+            break
+
+        line = _removesuffix(line, '(framework directory)')
+
+        yield line.strip()
+
+def _get_include_paths(cc_path):
+    result = subprocess.run([cc_path, '-E', '-Wp,-v', '-'],
+                            stdin=subprocess.DEVNULL,
+                            capture_output=True,
+                            check=True,
+                            text=True)
+
+    return _get_paths_from_output(result.stderr)
+
+def get_include_args(cc_path='clang'):
+    return ['-I{path}'.format(path=path) for path in _get_include_paths(cc_path)]
+
+if __name__ == '__main__':
+    import pprint
+    import sys
+
+    cc_path = sys.argv[1] if len(sys.argv) > 1 else 'clang'
+
+    pprint.pprint(get_include_args(cc_path))

--- a/hawkmoth/util/strutil.py
+++ b/hawkmoth/util/strutil.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2021, Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+
+def args_as_list(args):
+    if isinstance(args, str):
+        args = [s.strip() for s in args.split(',') if len(s.strip()) > 0]
+    if args is None:
+        args = []
+    return args


### PR DESCRIPTION
Fixes #29
Superseeds #39 

Mostly cleanups and refactoring to make clang arg manipulation easier both internally and for the users, and provide a helper for querying the info from the compiler. This way, it's up to the user to tie the arguments together at `conf.py` level, and the code base stays clean.
