### PR TITLE
treewide: start using Python 3.6+ f-strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ welcome both as emailed patches to the mailing list and as pull requests.
 Dependencies
 ------------
 
-- Python 3.4
+- Python 3.6
 - Sphinx 3
 - Clang 6.0
 - Python 3 Bindings for Clang 6.0

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -54,9 +54,9 @@ class CAutoDocDirective(Directive):
 
         for (severity, filename, lineno, msg) in errors:
             if filename:
-                toprint = '{}:{}: {}'.format(filename, lineno, msg)
+                toprint = f'{filename}:{lineno}: {msg}'
             else:
-                toprint = '{}'.format(msg)
+                toprint = f'{msg}'
 
             if severity.value <= env.app.verbosity:
                 self.logger.log(self._log_lvl[severity], toprint,
@@ -98,16 +98,14 @@ class CAutoDocDirective(Directive):
         for pattern in self.arguments[0].split():
             filenames = glob.glob(env.config.cautodoc_root + '/' + pattern)
             if len(filenames) == 0:
-                fmt = 'Pattern "{pat}" does not match any files.'
-                self.logger.warning(fmt.format(pat=pattern),
+                self.logger.warning(f'Pattern "{pattern}" does not match any files.',
                                     location=(env.docname, self.lineno))
                 continue
 
             for filename in filenames:
                 mode = os.stat(filename).st_mode
                 if stat.S_ISDIR(mode):
-                    fmt = 'Path "{name}" matching pattern "{pat}" is a directory.'
-                    self.logger.warning(fmt.format(name=filename, pat=pattern),
+                    self.logger.warning(f'Path "{filename}" matching pattern "{pattern}" is a directory.',
                                         location=(env.docname, self.lineno))
                     continue
 

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -38,14 +38,14 @@ def main():
 
     for (doc, meta) in docs:
         if args.verbose:
-            print('# {}'.format(meta))
+            print(f'# {meta}'
         print(doc)
 
     for (severity, filename, lineno, msg) in errors:
         if filename:
-            print('{}: {}:{}: {}'.format(severity.name,
-                                         filename, lineno, msg), file=sys.stderr)
+            print('f{severity.name}: {filename}:{lineno}: {msg}',
+                  file=sys.stderr)
         else:
-            print('{}: {}'.format(severity.name, msg), file=sys.stderr)
+            print(f'{severity.name}: {msg}', file=sys.stderr)
 
 main()

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -173,12 +173,7 @@ def _function_pointer_fixup(ttype, name):
     brackets = mo.group('brackets') if mo.group('brackets') is not None else ''
     end = mo.group('end')
 
-    name = '{begin}({stars}{qual}{name}{brackets}){end}'.format(begin=begin,
-                                                                stars=stars,
-                                                                qual=qual,
-                                                                name=name,
-                                                                brackets=brackets,
-                                                                end=end)
+    name = f'{begin}({stars}{qual}{name}{brackets}){end}'
     ttype = ''
 
     return ttype, name
@@ -270,8 +265,7 @@ def _recursive_parse(comments, cursor, nest, transform):
                     arg_ttype, arg_name = _array_fixup(c.type.spelling, c.spelling)
                     arg_ttype, arg_name = _function_pointer_fixup(arg_ttype, arg_name)
 
-                    args.append('{ttype} {name}'.format(ttype=arg_ttype,
-                                                        name=arg_name))
+                    args.append(f'{arg_ttype} {arg_name}')
 
             if cursor.type.is_function_variadic():
                 args.append('...')
@@ -287,9 +281,8 @@ def _recursive_parse(comments, cursor, nest, transform):
     # it doesn't break. I.e. the parser needs to pass warnings and errors to the
     # Sphinx extension instead of polluting the generated output.
     fmt = docstr.Type.TEXT
-    text = 'warning: unhandled cursor {kind} {name}\n'.format(
-        kind=str(cursor.kind),
-        name=cursor.spelling)
+    kind = str(cursor.kind)
+    text = f'warning: unhandled cursor {kind} {cursor.spelling}\n'
 
     doc = docstr.generate(text=text, fmt=fmt)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
     Topic :: Software Development :: Documentation
 
 [options]
-python_requires = ~=3.4
+python_requires = ~=3.6
 install_requires =
     sphinx >= 3
     # clang, depend on distro packaging

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -16,11 +16,10 @@ def _get_output(input_filename, app, status, warning, **options):
                     testenv.modify_filename(input_filename, dir=app.srcdir))
 
     with open(os.path.join(app.srcdir, 'index.rst'), 'w') as f:
-        fmt = '.. c:autodoc:: {source}\n'
-        f.write(fmt.format(source=os.path.basename(input_filename)))
+        source = os.path.basename(input_filename)
+        f.write(f'.. c:autodoc:: {source}\n')
         for key in [k for k in options.keys() if k in testenv.directive_options]:
-            fmt = '   :{key}: {value}\n'
-            f.write(fmt.format(key=key, value=options[key]))
+            f.write(f'   :{key}: {options[key]}\n')
 
     app.build()
 

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -24,7 +24,7 @@ def _get_output(input_filename, **options):
         docs_str += doc + '\n'
 
     for (severity, filename, lineno, msg) in errors:
-        errors_str += '{}: {}: {}\n'.format(severity.name, lineno, msg)
+        errors_str += f'{severity.name}: {lineno}: {msg}\n'
 
     return docs_str, errors_str
 


### PR DESCRIPTION
Python f-strings make the code cleaner. Also bump the Python version
requirement to 3.6.

Fixes: #40