### PR TITLE
System include path v3

### DIFF
--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -73,6 +73,18 @@ The extension has a few configuration options that can be set in ``conf.py``:
 
       cautodoc_clang = ['-I/path/to/include', '-DHAWKMOTH']
 
+   Hawkmoth provides a convenience helper for querying the include path from the
+   compiler, and providing them as ``-I`` options:
+
+   .. code-block:: python
+
+      from hawkmoth.util import compiler
+
+      cautodoc_clang = compiler.get_include_args()
+
+   You can also pass in the compiler to use, for example
+   ``get_include_args('gcc')``.
+
 Directive
 ---------
 

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -61,11 +61,17 @@ The extension has a few configuration options that can be set in ``conf.py``:
       are likely to change.
 
 .. py:data:: cautodoc_clang
-   :type: str
+   :type: list
 
-   A comma separated list of arguments to pass to ``clang`` while parsing the
-   source, typically to define macros for conditional compilation, for example
-   ``-DHAWKMOTH``. No arguments are passed by default.
+   A list of arguments to pass to ``clang`` while parsing the source, typically
+   to add directories to include file search path, or to define macros for
+   conditional compilation. No arguments are passed by default.
+
+   Example:
+
+   .. code-block:: python
+
+      cautodoc_clang = ['-I/path/to/include', '-DHAWKMOTH']
 
 Directive
 ---------

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -87,7 +87,7 @@ This module provides the following new directive:
    .. rst:directive:option:: clang
       :type: text
 
-      The ``clang`` option overrides the :data:`cautodoc_clang` configuration
+      The ``clang`` option extends the :data:`cautodoc_clang` configuration
       option.
 
 Examples

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -22,7 +22,7 @@ from sphinx.util.docutils import switch_source_input
 from sphinx.util import logging
 
 from hawkmoth.parser import parse, ErrorLevel
-from hawkmoth.util import doccompat
+from hawkmoth.util import doccompat, strutil
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
@@ -65,7 +65,9 @@ class CAutoDocDirective(Directive):
     def __get_clang_args(self):
         env = self.state.document.settings.env
 
-        clang_args = self.options.get('clang', env.config.cautodoc_clang)
+        clang_args = strutil.args_as_list(env.config.cautodoc_clang)
+
+        clang_args.extend(strutil.args_as_list(self.options.get('clang')))
 
         return clang_args
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -122,9 +122,9 @@ class CAutoDocDirective(Directive):
 
 def setup(app):
     app.require_sphinx('3.0')
-    app.add_config_value('cautodoc_root', app.confdir, 'env')
-    app.add_config_value('cautodoc_compat', None, 'env')
-    app.add_config_value('cautodoc_clang', None, 'env')
+    app.add_config_value('cautodoc_root', app.confdir, 'env', [str])
+    app.add_config_value('cautodoc_compat', None, 'env', [str])
+    app.add_config_value('cautodoc_clang', None, 'env', [str])
     app.add_directive_to_domain('c', 'autodoc', CAutoDocDirective)
 
     return dict(version = __version__,

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -62,6 +62,13 @@ class CAutoDocDirective(Directive):
                 self.logger.log(self._log_lvl[severity], toprint,
                                 location=(env.docname, self.lineno))
 
+    def __get_clang_args(self):
+        env = self.state.document.settings.env
+
+        clang_args = self.options.get('clang', env.config.cautodoc_clang)
+
+        return clang_args
+
     def __get_transform(self):
         env = self.state.document.settings.env
 
@@ -74,11 +81,10 @@ class CAutoDocDirective(Directive):
     def __parse(self, viewlist, filename):
         env = self.state.document.settings.env
 
-        clang = self.options.get('clang', env.config.cautodoc_clang)
-
+        clang_args = self.__get_clang_args()
         transform = self.__get_transform()
 
-        comments, errors = parse(filename, transform=transform, clang=clang)
+        comments, errors = parse(filename, transform=transform, clang=clang_args)
 
         self.__display_parser_diagnostics(errors)
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -65,7 +65,7 @@ class CAutoDocDirective(Directive):
     def __get_clang_args(self):
         env = self.state.document.settings.env
 
-        clang_args = strutil.args_as_list(env.config.cautodoc_clang)
+        clang_args = env.config.cautodoc_clang.copy()
 
         clang_args.extend(strutil.args_as_list(self.options.get('clang')))
 
@@ -132,7 +132,7 @@ def setup(app):
     app.require_sphinx('3.0')
     app.add_config_value('cautodoc_root', app.confdir, 'env', [str])
     app.add_config_value('cautodoc_compat', None, 'env', [str])
-    app.add_config_value('cautodoc_clang', None, 'env', [str])
+    app.add_config_value('cautodoc_clang', [], 'env', [list])
     app.add_directive_to_domain('c', 'autodoc', CAutoDocDirective)
 
     return dict(version = __version__,

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -26,8 +26,8 @@ def main():
                                  'javadoc-liberal',
                                  'kernel-doc'],
                         help='Compatibility options. See cautodoc_compat.')
-    parser.add_argument('--clang', metavar='PARAM[,PARAM,...]',
-                        help='Arguments to pass to clang. See cautodoc_clang.')
+    parser.add_argument('--clang', metavar='PARAM', action='append',
+                        help='Argument to pass to Clang. May be specified multiple times. See cautodoc_clang.')
     parser.add_argument('--verbose', dest='verbose', action='store_true',
                         help='Verbose output.')
     args = parser.parse_args()

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -313,10 +313,8 @@ def parse(filename, **options):
 
     errors = []
     args = options.get('clang')
-    if args is not None:
+    if isinstance(args, str):
         args = [s.strip() for s in args.split(',') if len(s.strip()) > 0]
-        if len(args) == 0:
-            args = None
 
     index = Index.create()
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -42,7 +42,7 @@ from clang.cindex import Index, TranslationUnit
 from clang.cindex import SourceLocation, SourceRange
 from clang.cindex import TokenKind, TokenGroup
 
-from hawkmoth.util import docstr
+from hawkmoth.util import docstr, doccompat, strutil
 
 class ErrorLevel(enum.Enum):
     """
@@ -312,9 +312,7 @@ def clang_diagnostics(errors, diagnostics):
 def parse(filename, **options):
 
     errors = []
-    args = options.get('clang')
-    if isinstance(args, str):
-        args = [s.strip() for s in args.split(',') if len(s.strip()) > 0]
+    args = strutil.args_as_list(options.get('clang'))
 
     index = Index.create()
 

--- a/hawkmoth/util/compiler.py
+++ b/hawkmoth/util/compiler.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2021 Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+"""
+Compiler helpers
+================
+
+This module provides helper functions to access compiler information outside of
+the Clang Python Bindings, for example system include paths.
+"""
+
+import subprocess
+
+def _removesuffix(s, suffix):
+    if suffix and s.endswith(suffix):
+        return s[:-len(suffix)]
+    else:
+        return s[:]
+
+def _get_paths_from_output(output):
+    started = False
+    for line in output.splitlines():
+        if not started:
+            if line == '#include <...> search starts here:':
+                started = True
+            continue
+
+        if line == 'End of search list.':
+            break
+
+        # Clang on macOS may print this.
+        line = _removesuffix(line, '(framework directory)')
+
+        yield line.strip()
+
+def _get_include_paths(cc_path):
+    result = subprocess.run([cc_path, '-E', '-Wp,-v', '-'],
+                            stdin=subprocess.DEVNULL,
+                            capture_output=True,
+                            check=True,
+                            text=True)
+
+    return _get_paths_from_output(result.stderr)
+
+def get_include_args(cc_path='clang'):
+    return ['-I{path}'.format(path=path) for path in _get_include_paths(cc_path)]
+
+if __name__ == '__main__':
+    import pprint
+    import sys
+
+    cc_path = sys.argv[1] if len(sys.argv) > 1 else 'clang'
+
+    pprint.pprint(get_include_args(cc_path))

--- a/hawkmoth/util/strutil.py
+++ b/hawkmoth/util/strutil.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2021, Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+
+def args_as_list(args):
+    if isinstance(args, str):
+        args = [s.strip() for s in args.split(',') if len(s.strip()) > 0]
+    if args is None:
+        args = []
+    return args


### PR DESCRIPTION
Superseeds: #44 

Some refactoring over the previous series. Main difference is converting the user facing `cautodoc_clang` configuration to a list. (It may still be passed as string to `parse()` due to tests, but that cleanup is for another time.)
