### PR TITLE
Transformations v3

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,6 +57,7 @@ except ImportError:
     extensions.append('automock')
 
 from sphinx.ext.napoleon import docstring, Config
+from hawkmoth.util import doccompat
 
 def napoleon_transform(comment):
     config = Config(napoleon_use_rtype=False)
@@ -64,6 +65,7 @@ def napoleon_transform(comment):
 
 cautodoc_transformations = {
     'napoleon': napoleon_transform,
+    'javadoc-liberal': doccompat.javadoc_liberal,
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,6 +56,16 @@ except ImportError:
     # into the documentation instead of generating.
     extensions.append('automock')
 
+from sphinx.ext.napoleon import docstring, Config
+
+def napoleon_transform(comment):
+    config = Config(napoleon_use_rtype=False)
+    return str(docstring.GoogleDocstring(comment, config))
+
+cautodoc_transformations = {
+    'napoleon': napoleon_transform,
+}
+
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
 

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -180,6 +180,29 @@ Output
 .. c:autodoc:: examples/example-70-preprocessor.c
    :clang: -DDEEP_THOUGHT
 
+Transform
+---------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-75-transform.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autodoc:: examples/example-75-transform.c
+      :transform: napoleon
+
+Output
+~~~~~~
+
+.. c:autodoc:: examples/example-75-transform.c
+   :transform: napoleon
+
 Compat
 ------
 

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -218,13 +218,13 @@ Directive
 .. code-block:: rest
 
    .. c:autodoc:: examples/example-80-compat.c
-      :compat: javadoc-liberal
+      :transform: javadoc-liberal
 
 Output
 ~~~~~~
 
 .. c:autodoc:: examples/example-80-compat.c
-   :compat: javadoc-liberal
+   :transform: javadoc-liberal
 
 Generic
 -------

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -48,6 +48,47 @@ The extension has a few configuration options that can be set in ``conf.py``:
       import os
       cautodoc_root = os.path.abspath('my/sources/dir')
 
+.. py:data:: cautodoc_transformations
+   :type: dict
+
+   Transformation functions for the :rst:dir:`c:autodoc` directive ``transform``
+   option. This is a dictionary that maps names to functions. The names can be
+   used in the directive ``transform`` option. The functions are expected to
+   take a (multi-line) comment string as a parameter, and return the transformed
+   string. This can be used to perform custom conversions of the comments,
+   including, but not limited to, Javadoc-style compat conversions.
+
+   The special key ``None``, if present, is used to convert everything, unless
+   overridden in the directive ``transform`` option. The special value ``None``
+   means no transformation is to be done.
+
+   For example, this configuration would transform everything using
+   ``default_transform`` function by default, unless overridden in the directive
+   ``transform`` option with ``javadoc`` or ``none``. The former would use
+   ``javadoc_transform`` function, and the latter would bypass transform
+   altogether.
+
+   .. code-block:: python
+
+      cautodoc_transformations = {
+          None: default_transform,
+	  'javadoc': javadoc_transform,
+	  'none': None,
+      }
+
+   The example below shows how to use Hawkmoth's existing compat functions in
+   ``conf.py``, for migration from deprecated ``cautodoc_compat``. Also replace
+   ``:compat:`` with ``:transform:``.
+
+   .. code-block:: python
+
+      from hawkmoth.util import doccompat
+      cautodoc_transformations = {
+          'javadoc-basic': doccompat.javadoc,
+          'javadoc-liberal': doccompat.javadoc_liberal,
+          'kernel-doc': doccompat.kerneldoc,
+      }
+
 .. py:data:: cautodoc_compat
    :type: str
 
@@ -57,8 +98,9 @@ The extension has a few configuration options that can be set in ``conf.py``:
 
    .. warning::
 
-      The compatibility options and the subset of supported syntax elements
-      are likely to change.
+      The cautodoc_compat option has been deprecated in favour of the
+      :data:`cautodoc_transformations` option and the :rst:dir:`c:autodoc`
+      directive ``transform`` option, and will be removed in the future.
 
 .. py:data:: cautodoc_clang
    :type: list
@@ -96,11 +138,24 @@ This module provides the following new directive:
    separated list of filename patterns given as arguments. The patterns are
    interpreted relative to the :data:`cautodoc_root` configuration option.
 
+   .. rst:directive:option:: transform
+      :type: text
+
+      Name of the transformation function specified in
+      :data:`cautodoc_transformations` to use for converting the comments. This
+      value overrides the default in :data:`cautodoc_transformations`.
+
    .. rst:directive:option:: compat
       :type: text
 
       The ``compat`` option overrides the :data:`cautodoc_compat` configuration
       option.
+
+      .. warning::
+
+	 The compat option has been deprecated in favour of the
+	 :data:`cautodoc_transformations` option and the :rst:dir:`c:autodoc`
+	 directive ``transform`` option, and will be removed in the future.
 
    .. rst:directive:option:: clang
       :type: text

--- a/doc/update-examples
+++ b/doc/update-examples
@@ -31,7 +31,7 @@ EOF
 read_options()
 {
 	if [ -e "$1" ]; then
-		sed -n "s/ /\n/g;s/\(compat\|clang\)=\([a-zA-Z0-9_,-]\+\)/:\1: \2/gp" < $1
+		sed -n "s/ /\n/g;s/\(compat\|clang\|transform\)=\([a-zA-Z0-9_,-]\+\)/:\1: \2/gp" < $1
 	fi
 }
 

--- a/hawkmoth/util/doccompat.py
+++ b/hawkmoth/util/doccompat.py
@@ -12,16 +12,9 @@ import re
 
 # Basic Javadoc/Doxygen/kernel-doc import
 #
-# FIXME: One of the design goals of Hawkmoth is to keep things simple. There's a
-# fine balance between sticking to that goal and adding compat code to
-# facilitate any kind of migration to Hawkmoth. The compat code could be turned
-# into a fairly simple plugin architecture, with some basic compat builtins, and
-# the users could still extend the compat features to fit their specific needs.
-#
 # FIXME: try to preserve whitespace better
-#
 
-def javadoc(comment, **options):
+def javadoc(comment):
     """Basic javadoc conversion to reStructuredText"""
 
     # @param
@@ -48,7 +41,7 @@ def javadoc(comment, **options):
 
     return comment
 
-def javadoc_liberal(comment, **options):
+def javadoc_liberal(comment):
     """Liberal javadoc conversion to reStructuredText"""
 
     comment = javadoc(comment)
@@ -60,7 +53,7 @@ def javadoc_liberal(comment, **options):
 
     return comment
 
-def kerneldoc(comment, **options):
+def kerneldoc(comment):
     """Basic kernel-doc conversion to reStructuredText"""
 
     comment = re.sub(r"(?m)^([ \t]*)@(returns?|RETURNS?):([ \t]+|$)",
@@ -82,6 +75,6 @@ def convert(comment, **options):
     }
 
     if transform in transformations:
-        comment = transformations[transform](comment, **options)
+        comment = transformations[transform](comment)
 
     return comment

--- a/hawkmoth/util/docstr.py
+++ b/hawkmoth/util/docstr.py
@@ -96,7 +96,7 @@ def generate(text, fmt=Type.TEXT, name=None,
 
     text = _strip(text)
 
-    if transform:
+    if transform is not None:
         text = transform(text)
 
     if args is not None:

--- a/test/conf.py
+++ b/test/conf.py
@@ -42,6 +42,16 @@ extensions = [
     'hawkmoth'
 ]
 
+from sphinx.ext.napoleon import docstring, Config
+
+def napoleon_transform(comment):
+    config = Config(napoleon_use_rtype=False)
+    return str(docstring.GoogleDocstring(comment, config))
+
+cautodoc_transformations = {
+    'napoleon': napoleon_transform,
+}
+
 # Add any paths that contain templates here, relative to this directory.
 #templates_path = ['_templates']
 

--- a/test/conf.py
+++ b/test/conf.py
@@ -43,6 +43,7 @@ extensions = [
 ]
 
 from sphinx.ext.napoleon import docstring, Config
+from hawkmoth.util import doccompat
 
 def napoleon_transform(comment):
     config = Config(napoleon_use_rtype=False)
@@ -50,6 +51,7 @@ def napoleon_transform(comment):
 
 cautodoc_transformations = {
     'napoleon': napoleon_transform,
+    'javadoc-liberal': doccompat.javadoc_liberal,
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/test/example-75-transform.c
+++ b/test/example-75-transform.c
@@ -1,0 +1,15 @@
+/**
+ * Custom comment transformations.
+ *
+ * Transformations require ``cautodoc_transformations`` configuration in
+ * ``conf.py``. In this example, Napoleon is used to interpret another
+ * documentation comment format.
+ *
+ * Args:
+ *     foo: This is foo.
+ *     bar: This is bar.
+ *
+ * Return:
+ *     Status.
+ */
+int napoleon(int foo, char *bar);

--- a/test/example-75-transform.options
+++ b/test/example-75-transform.options
@@ -1,0 +1,1 @@
+transform=napoleon

--- a/test/example-75-transform.rst
+++ b/test/example-75-transform.rst
@@ -1,0 +1,15 @@
+
+.. c:function:: int napoleon(int foo, char * bar)
+
+   Custom comment transformations.
+
+   Transformations require ``cautodoc_transformations`` configuration in
+   ``conf.py``. In this example, Napoleon is used to interpret another
+   documentation comment format.
+
+   :param foo: This is foo.
+   :param bar: This is bar.
+
+   :returns: Status.
+
+

--- a/test/example-80-compat.c
+++ b/test/example-80-compat.c
@@ -1,5 +1,9 @@
 /**
- * List frobnicator.
+ * Compat comment transformations.
+ *
+ * Transformations require ``cautodoc_transformations`` configuration in
+ * ``conf.py``. In this example, a transformation is used to support
+ * Javadoc-style documentation comments.
  *
  * @param list The list to frob.
  * @param mode The frobnication mode.

--- a/test/example-80-compat.options
+++ b/test/example-80-compat.options
@@ -1,1 +1,1 @@
-compat=javadoc-liberal
+transform=javadoc-liberal

--- a/test/example-80-compat.rst
+++ b/test/example-80-compat.rst
@@ -1,7 +1,11 @@
 
 .. c:function:: int frob2(struct list * list, enum mode mode)
 
-   List frobnicator.
+   Compat comment transformations.
+
+   Transformations require ``cautodoc_transformations`` configuration in
+   ``conf.py``. In this example, a transformation is used to support
+   Javadoc-style documentation comments.
 
 
    :param list: The list to frob.

--- a/test/example-80-compat.stderr
+++ b/test/example-80-compat.stderr
@@ -1,2 +1,2 @@
-WARNING: 9: declaration of 'struct list' will not be visible outside of this function
-WARNING: 9: declaration of 'enum mode' will not be visible outside of this function
+WARNING: 13: declaration of 'struct list' will not be visible outside of this function
+WARNING: 13: declaration of 'enum mode' will not be visible outside of this function

--- a/test/test_hawkmoth.py
+++ b/test/test_hawkmoth.py
@@ -8,7 +8,7 @@ import pytest
 
 from hawkmoth.parser import parse
 from hawkmoth.util import doccompat
-from test import testenv
+from test import conf, testenv
 
 def _get_output(input_filename, **options):
     docs_str = ''
@@ -17,6 +17,10 @@ def _get_output(input_filename, **options):
     transform = options.pop('compat', None)
     if transform is not None:
         options['transform'] = lambda comment: doccompat.convert(comment, transform=transform)
+    else:
+        transform = options.pop('transform', None)
+        if transform is not None:
+            options['transform'] = conf.cautodoc_transformations[transform]
 
     docs, errors = parse(input_filename, **options)
 

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -26,6 +26,7 @@ def get_testcases(path):
 directive_options = [
     'compat',
     'clang',
+    'transform',
 ]
 
 def get_testcase_options(testcase):


### PR DESCRIPTION
The discussion is still ongoing in #49, and I guess we should finish it there. This pull request reflects my last comments:

- Remove the special keywords ``none`` and ``default`` altogether, and use ``None`` value instead. (Use of ``None`` may be debatable, but let's finish the discussion in #49.)
- Remove ``**options`` from transformations for simplicity.
