### PR TITLE
Autodoc draft

### DIFF
--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -3,7 +3,7 @@
 C Autodoc Extension
 ===================
 
-Hawkmoth provides a Sphinx extension that adds a new directive to the Sphinx
+Hawkmoth provides a Sphinx extension that adds new directives to the Sphinx
 :any:`C domain <sphinx:c-domain>` to incorporate formatted C source code
 comments into a document. Hawkmoth is Sphinx :any:`sphinx:sphinx.ext.autodoc`
 for C.
@@ -127,10 +127,13 @@ The extension has a few configuration options that can be set in ``conf.py``:
    You can also pass in the compiler to use, for example
    ``get_include_args('gcc')``.
 
-Directive
----------
+Directives
+----------
 
-This module provides the following new directive:
+Hawkmoth provides several new directives for incorporating documentation
+comments from C sources into the reStructuredText document. The
+:rst:dir:`c:autodoc` directive simply includes all the comments from any number
+of files, while the rest are for including documentation for specific symbols.
 
 .. rst:directive:: .. c:autodoc:: filename-pattern [...]
 
@@ -163,6 +166,37 @@ This module provides the following new directive:
       The ``clang`` option extends the :data:`cautodoc_clang` configuration
       option.
 
+.. rst:directive:: .. c:autovar:: filename name
+
+   Incorporate the documentation comment for the variable ``name`` in the file
+   ``filename``. The filename is interpreted relative to the
+   :data:`cautodoc_root` configuration option.
+
+.. rst:directive:: .. c:autotype:: filename name
+
+   Same as :rst:dir:`c:autovar` but for typedefs.
+
+.. rst:directive:: .. c:autostruct:: filename name
+
+   Same as :rst:dir:`c:autovar` but for structs.
+
+.. rst:directive:: .. c:autounion:: filename name
+
+   Same as :rst:dir:`c:autovar` but for unions.
+
+.. rst:directive:: .. c:autoenum:: filename name
+
+   Same as :rst:dir:`c:autovar` but for enums.
+
+.. rst:directive:: .. c:automacro:: filename name
+
+   Same as :rst:dir:`c:autovar` but for macros, including function-like macros.
+
+.. rst:directive:: .. c:autofunction:: filename name
+
+   Same as :rst:dir:`c:autovar` but for functions. (Use :rst:dir:`c:automacro`
+   for function-like macros.)
+
 Examples
 --------
 
@@ -171,6 +205,14 @@ The basic usage is:
 .. code-block:: rst
 
    .. c:autodoc:: interface.h
+
+Individual symbols:
+
+.. code-block:: rst
+
+   .. c:autofunction:: interface.h foo
+
+   .. c:autostruct:: interface.h bar
 
 Several files with compatibility and compiler options:
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -30,12 +30,9 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
 
 class CAutoDocDirective(SphinxDirective):
     """Extract all documentation comments from the specified file"""
-    required_argument = 1
-    optional_arguments = 1
+    required_arguments = 1
+    optional_arguments = 100 # arbitrary limit
     logger = logging.getLogger(__name__)
-
-    # Allow passing a variable number of file patterns as arguments
-    final_argument_whitespace = True
 
     option_spec = {
         'transform': directives.unchanged_required,
@@ -123,7 +120,7 @@ class CAutoDocDirective(SphinxDirective):
     def run(self):
         result = ViewList()
 
-        for pattern in self.arguments[0].split():
+        for pattern in self.arguments:
             filenames = glob.glob(self.env.config.cautodoc_root + '/' + pattern)
             if len(filenames) == 0:
                 self.logger.warning(f'Pattern "{pattern}" does not match any files.',

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -118,7 +118,7 @@ class CAutoDocDirective(SphinxDirective):
 
                 yield os.path.abspath(filename)
 
-    def __parse(self, viewlist, filename):
+    def __parse(self, filename):
         clang_args = self.__get_clang_args()
         transform = self.__get_transform()
 
@@ -128,6 +128,11 @@ class CAutoDocDirective(SphinxDirective):
         comments, errors = parse(filename, transform=transform, clang=clang_args)
 
         self.__display_parser_diagnostics(errors)
+
+        return comments
+
+    def __get_comments(self, viewlist, filename):
+        comments = self.__parse(filename)
 
         for (comment, meta) in comments:
             lineoffset = meta['line'] - 1
@@ -141,7 +146,7 @@ class CAutoDocDirective(SphinxDirective):
         result = ViewList()
 
         for filename in self.__get_filenames():
-            self.__parse(result, filename)
+            self.__get_comments(result, filename)
 
         # Parse the extracted reST
         with switch_source_input(self.state, result):

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -122,6 +122,9 @@ class CAutoDocDirective(SphinxDirective):
         clang_args = self.__get_clang_args()
         transform = self.__get_transform()
 
+        # Tell Sphinx about the dependency
+        self.env.note_dependency(filename)
+
         comments, errors = parse(filename, transform=transform, clang=clang_args)
 
         self.__display_parser_diagnostics(errors)
@@ -138,8 +141,6 @@ class CAutoDocDirective(SphinxDirective):
         result = ViewList()
 
         for filename in self.__get_filenames():
-            # Tell Sphinx about the dependency and parse the file
-            self.env.note_dependency(filename)
             self.__parse(result, filename)
 
         # Parse the extracted reST

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -15,10 +15,10 @@ import subprocess
 import sys
 
 from docutils import nodes, statemachine
-from docutils.parsers.rst import directives, Directive
+from docutils.parsers.rst import directives
 from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
-from sphinx.util.docutils import switch_source_input
+from sphinx.util.docutils import switch_source_input, SphinxDirective
 from sphinx.util import logging
 
 from hawkmoth.parser import parse, ErrorLevel
@@ -28,7 +28,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
-class CAutoDocDirective(Directive):
+class CAutoDocDirective(SphinxDirective):
     """Extract all documentation comments from the specified file"""
     required_argument = 1
     optional_arguments = 1
@@ -51,54 +51,46 @@ class CAutoDocDirective(Directive):
                 ErrorLevel.DEBUG: logging.LEVEL_NAMES['DEBUG']}
 
     def __display_parser_diagnostics(self, errors):
-        env = self.state.document.settings.env
-
         for (severity, filename, lineno, msg) in errors:
             if filename:
                 toprint = f'{filename}:{lineno}: {msg}'
             else:
                 toprint = f'{msg}'
 
-            if severity.value <= env.app.verbosity:
+            if severity.value <= self.env.app.verbosity:
                 self.logger.log(self._log_lvl[severity], toprint,
-                                location=(env.docname, self.lineno))
+                                location=(self.env.docname, self.lineno))
 
     def __get_clang_args(self):
-        env = self.state.document.settings.env
-
-        clang_args = env.config.cautodoc_clang.copy()
+        clang_args = self.env.config.cautodoc_clang.copy()
 
         clang_args.extend(strutil.args_as_list(self.options.get('clang')))
 
         return clang_args
 
     def __get_compat_transform(self):
-        env = self.state.document.settings.env
-
-        compat = self.options.get('compat', env.config.cautodoc_compat)
+        compat = self.options.get('compat', self.env.config.cautodoc_compat)
         if compat is None:
             return None
 
         fmt = 'cautodoc_compat and compat options are deprecated, please use cautodoc_transformations and transform options instead.'
-        self.logger.warning(fmt, location=(env.docname, self.lineno))
+        self.logger.warning(fmt, location=(self.env.docname, self.lineno))
 
         return lambda comment: doccompat.convert(comment, transform=compat)
 
     def __get_transform(self):
-        env = self.state.document.settings.env
-
         # Handle deprecated compat. To be removed.
         transform = self.__get_compat_transform()
         if transform is not None:
             return transform
 
-        transformations = env.config.cautodoc_transformations
+        transformations = self.env.config.cautodoc_transformations
         tropt = self.options.get('transform')
 
         if transformations is None:
             if tropt is not None:
                 self.logger.warning('transform specified without cautodoc_transformations config.',
-                                    location=(env.docname, self.lineno))
+                                    location=(self.env.docname, self.lineno))
 
             return None
 
@@ -106,15 +98,13 @@ class CAutoDocDirective(Directive):
         if tropt not in transformations:
             if tropt is not None:
                 self.logger.warning(f'unknown transformation "{tropt}".',
-                                    location=(env.docname, self.lineno))
+                                    location=(self.env.docname, self.lineno))
             return None
 
         # Note: None is a valid value for no transformation.
         return transformations.get(tropt)
 
     def __parse(self, viewlist, filename):
-        env = self.state.document.settings.env
-
         clang_args = self.__get_clang_args()
         transform = self.__get_transform()
 
@@ -131,26 +121,24 @@ class CAutoDocDirective(Directive):
                 lineoffset += 1
 
     def run(self):
-        env = self.state.document.settings.env
-
         result = ViewList()
 
         for pattern in self.arguments[0].split():
-            filenames = glob.glob(env.config.cautodoc_root + '/' + pattern)
+            filenames = glob.glob(self.env.config.cautodoc_root + '/' + pattern)
             if len(filenames) == 0:
                 self.logger.warning(f'Pattern "{pattern}" does not match any files.',
-                                    location=(env.docname, self.lineno))
+                                    location=(self.env.docname, self.lineno))
                 continue
 
             for filename in filenames:
                 mode = os.stat(filename).st_mode
                 if stat.S_ISDIR(mode):
                     self.logger.warning(f'Path "{filename}" matching pattern "{pattern}" is a directory.',
-                                        location=(env.docname, self.lineno))
+                                        location=(self.env.docname, self.lineno))
                     continue
 
                 # Tell Sphinx about the dependency and parse the file
-                env.note_dependency(os.path.abspath(filename))
+                self.env.note_dependency(os.path.abspath(filename))
                 self.__parse(result, filename)
 
         # Parse the extracted reST

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -139,10 +139,16 @@ class CAutoDocDirective(SphinxDirective):
 
         return comments
 
-    def __get_comments(self, viewlist, filename):
+    def __get_comments(self, viewlist, filename, doctypes=None, names=None):
         comments = self.__parse(filename)
 
         for (comment, meta) in comments:
+            if doctypes and meta['doctype'] not in doctypes:
+                continue
+
+            if names and meta['name'] not in names:
+                continue
+
             lineoffset = meta['line'] - 1
             lines = statemachine.string2lines(comment, 8,
                                               convert_whitespace=True)

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -122,12 +122,20 @@ class CAutoDocDirective(SphinxDirective):
         clang_args = self.__get_clang_args()
         transform = self.__get_transform()
 
+        parsed_files = self.env.temp_data.setdefault('cautodoc_parsed_files', {})
+
+        # FIXME: the output depends on transform and clang args
+        if filename in parsed_files:
+            return parsed_files[filename]
+
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
 
         comments, errors = parse(filename, transform=transform, clang=clang_args)
 
         self.__display_parser_diagnostics(errors)
+
+        parsed_files[filename] = comments
 
         return comments
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -23,6 +23,7 @@ from sphinx.util import logging
 
 from hawkmoth.parser import parse, ErrorLevel
 from hawkmoth.util import doccompat, strutil
+from hawkmoth.util.docstr import Type
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
@@ -140,7 +141,7 @@ class CAutoBaseDirective(SphinxDirective):
         result = ViewList()
 
         for filename in self._get_filenames():
-            self.__get_comments(result, filename)
+            self.__get_comments(result, filename, self.doctypes, self._get_names())
 
         # Parse the extracted reST
         with switch_source_input(self.state, result):
@@ -155,6 +156,8 @@ class CAutoDocDirective(CAutoBaseDirective):
     # Allow passing a variable number of file patterns as arguments
     required_arguments = 1
     optional_arguments = 100 # arbitrary limit
+
+    doctypes = None
 
     def _get_filenames(self):
         for pattern in self.arguments:
@@ -173,6 +176,45 @@ class CAutoDocDirective(CAutoBaseDirective):
 
                 yield os.path.abspath(filename)
 
+    def _get_names(self):
+        return None
+
+# Base class for named stuff
+class CAutoSymbolDirective(CAutoBaseDirective):
+    """Extract specified documentation comments from the specified file"""
+
+    required_arguments = 2
+    optional_arguments = 0
+
+    doctypes = None
+
+    def _get_filenames(self):
+        return [os.path.abspath(os.path.join(self.env.config.cautodoc_root, self.arguments[0]))]
+
+    def _get_names(self):
+        return [self.arguments[1]]
+
+class CAutoVarDirective(CAutoSymbolDirective):
+    doctypes = [Type.VAR]
+
+class CAutoTypeDirective(CAutoSymbolDirective):
+    doctypes = [Type.TYPE]
+
+class CAutoStructDirective(CAutoSymbolDirective):
+    doctypes = [Type.STRUCT]
+
+class CAutoUnionDirective(CAutoSymbolDirective):
+    doctypes = [Type.UNION]
+
+class CAutoEnumDirective(CAutoSymbolDirective):
+    doctypes = [Type.ENUM]
+
+class CAutoMacroDirective(CAutoSymbolDirective):
+    doctypes = [Type.MACRO, Type.MACRO_FUNC]
+
+class CAutoFunctionDirective(CAutoSymbolDirective):
+    doctypes = [Type.FUNC]
+
 def setup(app):
     app.require_sphinx('3.0')
     app.add_config_value('cautodoc_root', app.confdir, 'env', [str])
@@ -180,6 +222,13 @@ def setup(app):
     app.add_config_value('cautodoc_transformations', None, 'env', [dict])
     app.add_config_value('cautodoc_clang', [], 'env', [list])
     app.add_directive_to_domain('c', 'autodoc', CAutoDocDirective)
+    app.add_directive_to_domain('c', 'autovar', CAutoVarDirective)
+    app.add_directive_to_domain('c', 'autotype', CAutoTypeDirective)
+    app.add_directive_to_domain('c', 'autostruct', CAutoStructDirective)
+    app.add_directive_to_domain('c', 'autounion', CAutoUnionDirective)
+    app.add_directive_to_domain('c', 'autoenum', CAutoEnumDirective)
+    app.add_directive_to_domain('c', 'automacro', CAutoMacroDirective)
+    app.add_directive_to_domain('c', 'autofunction', CAutoFunctionDirective)
 
     return dict(version = __version__,
                 parallel_read_safe = True, parallel_write_safe = True)

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -115,7 +115,11 @@ def _result(comment, cursor=None, fmt=docstr.Type.TEXT, nest=0,
 
     doc = docstr.nest(doc, nest)
 
-    meta = {'line': comment.extent.start.line}
+    meta = {
+        'line': comment.extent.start.line,
+        'doctype': fmt,
+        'name': name,
+    }
     if cursor:
         meta['cursor.kind']        = cursor.kind,
         meta['cursor.displayname'] = cursor.displayname,


### PR DESCRIPTION
This is a draft for implementing #51.
The big missing items are tests and incorporating the struct/union/enum member documentation recursively too.
There's some basic documentation included, but it's simply:
```
.. c:autofunction:: file.c function_name
```
and similarly for other types of symbols. The `c:auto<X>::` directive names map directly to the [Sphinx C Domain](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#the-c-domain) `c:<X>::` directives.
I'm still a bit unsure about the directive arguments (mainly about creating something that's not easy to extend). I'll keep pondering.

