### PR TITLE
New auto* directives to pull in individual structs/functions/enums, etc.

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -39,8 +39,41 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-10-macro.c
    
+
+
+
+
+Automacro
+---------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-11-automacro.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:automacro:: examples/example-11-automacro.c DIE
+      
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Automacro
+
+.. c:automacro:: examples/example-11-automacro.c DIE
+   
+
+.. c:namespace-pop::
+
 
 Variable
 --------
@@ -62,8 +95,41 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-20-variable.c
    
+
+
+
+
+Autovar
+-------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-21-autovar.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autovar:: examples/example-21-autovar.c meaning_of_life
+      
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autovar
+
+.. c:autovar:: examples/example-21-autovar.c meaning_of_life
+   
+
+.. c:namespace-pop::
+
 
 Typedef
 -------
@@ -85,8 +151,41 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-30-typedef.c
    
+
+
+
+
+Autotype
+--------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-31-autotype.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autotype:: examples/example-31-autotype.c list_data_t
+      
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autotype
+
+.. c:autotype:: examples/example-31-autotype.c list_data_t
+   
+
+.. c:namespace-pop::
+
 
 Enum
 ----
@@ -108,8 +207,41 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-40-enum.c
    
+
+
+
+
+Autoenum
+--------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-41-autoenum.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autoenum:: examples/example-41-autoenum.c mode
+      
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autoenum
+
+.. c:autoenum:: examples/example-41-autoenum.c mode
+   
+
+.. c:namespace-pop::
+
 
 Struct
 ------
@@ -131,8 +263,41 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-50-struct.c
    
+
+
+
+
+Autostruct
+----------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-51-autostruct.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autostruct:: examples/example-51-autostruct.c list
+      
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autostruct
+
+.. c:autostruct:: examples/example-51-autostruct.c list
+   
+
+.. c:namespace-pop::
+
 
 Function
 --------
@@ -154,8 +319,13 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-70-function.c
    
+
+
+
 
 Preprocessor
 ------------
@@ -177,8 +347,41 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-70-preprocessor.c
    :clang: -DDEEP_THOUGHT
+
+
+
+
+Autofunction
+------------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-71-autofunction.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autofunction:: examples/example-71-autofunction.c frob
+      
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autofunction
+
+.. c:autofunction:: examples/example-71-autofunction.c frob
+   
+
+.. c:namespace-pop::
+
 
 Transform
 ---------
@@ -200,8 +403,13 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-75-transform.c
    :transform: napoleon
+
+
+
 
 Compat
 ------
@@ -223,8 +431,13 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-80-compat.c
    :transform: javadoc-liberal
+
+
+
 
 Generic
 -------
@@ -246,6 +459,11 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-90-generic.c
    
+
+
+
 

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -3,7 +3,7 @@
 C Autodoc Extension
 ===================
 
-Hawkmoth provides a Sphinx extension that adds a new directive to the Sphinx
+Hawkmoth provides a Sphinx extension that adds new directives to the Sphinx
 :any:`C domain <sphinx:c-domain>` to incorporate formatted C source code
 comments into a document. Hawkmoth is Sphinx :any:`sphinx:sphinx.ext.autodoc`
 for C.
@@ -127,10 +127,13 @@ The extension has a few configuration options that can be set in ``conf.py``:
    You can also pass in the compiler to use, for example
    ``get_include_args('gcc')``.
 
-Directive
----------
+Directives
+----------
 
-This module provides the following new directive:
+Hawkmoth provides several new directives for incorporating documentation
+comments from C sources into the reStructuredText document. The
+:rst:dir:`c:autodoc` directive simply includes all the comments from any number
+of files, while the rest are for including documentation for specific symbols.
 
 .. rst:directive:: .. c:autodoc:: filename-pattern [...]
 
@@ -163,6 +166,37 @@ This module provides the following new directive:
       The ``clang`` option extends the :data:`cautodoc_clang` configuration
       option.
 
+.. rst:directive:: .. c:autovar:: filename name
+
+   Incorporate the documentation comment for the variable ``name`` in the file
+   ``filename``. The filename is interpreted relative to the
+   :data:`cautodoc_root` configuration option.
+
+.. rst:directive:: .. c:autotype:: filename name
+
+   Same as :rst:dir:`c:autovar` but for typedefs.
+
+.. rst:directive:: .. c:autostruct:: filename name
+
+   Same as :rst:dir:`c:autovar` but for structs.
+
+.. rst:directive:: .. c:autounion:: filename name
+
+   Same as :rst:dir:`c:autovar` but for unions.
+
+.. rst:directive:: .. c:autoenum:: filename name
+
+   Same as :rst:dir:`c:autovar` but for enums.
+
+.. rst:directive:: .. c:automacro:: filename name
+
+   Same as :rst:dir:`c:autovar` but for macros, including function-like macros.
+
+.. rst:directive:: .. c:autofunction:: filename name
+
+   Same as :rst:dir:`c:autovar` but for functions. (Use :rst:dir:`c:automacro`
+   for function-like macros.)
+
 Examples
 --------
 
@@ -171,6 +205,14 @@ The basic usage is:
 .. code-block:: rst
 
    .. c:autodoc:: interface.h
+
+Individual symbols:
+
+.. code-block:: rst
+
+   .. c:autofunction:: interface.h foo
+
+   .. c:autostruct:: interface.h bar
 
 Several files with compatibility and compiler options:
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -118,20 +118,25 @@ class CAutoDocDirective(SphinxDirective):
 
                 yield os.path.abspath(filename)
 
-    def __parse(self, viewlist, filename):
+    def __parse(self, filename):
         clang_args = self.__get_clang_args()
-        transform = self.__get_transform()
 
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
 
-        comments, errors = parse(filename, clang=clang_args)
+        docstrings, errors = parse(filename, clang=clang_args)
 
         self.__display_parser_diagnostics(errors)
 
-        for comment in comments.recursive_walk():
-            lineoffset = comment.get_line() - 1
-            lines = statemachine.string2lines(comment.get_docstring(transform=transform), 8,
+        return docstrings
+
+    def __get_docstrings(self, viewlist, filename):
+        transform = self.__get_transform()
+        docstrings = self.__parse(filename)
+
+        for docstr in docstrings.recursive_walk():
+            lineoffset = docstr.get_line() - 1
+            lines = statemachine.string2lines(docstr.get_docstring(transform=transform), 8,
                                               convert_whitespace=True)
             for line in lines:
                 viewlist.append(line, filename, lineoffset)
@@ -141,7 +146,7 @@ class CAutoDocDirective(SphinxDirective):
         result = ViewList()
 
         for filename in self.__get_filenames():
-            self.__parse(result, filename)
+            self.__get_docstrings(result, filename)
 
         # Parse the extracted reST
         with switch_source_input(self.state, result):

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -114,7 +114,7 @@ class CAutoBaseDirective(SphinxDirective):
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
 
-        docstrings, errors = parse(filename, clang=clang_args)
+        docstrings, errors = parse(filename, clang_args=clang_args)
 
         self.__display_parser_diagnostics(errors)
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -141,11 +141,11 @@ class CAutoDocDirective(SphinxDirective):
 
         return docstrings
 
-    def __get_docstrings(self, viewlist, filename):
+    def __get_docstrings(self, viewlist, filename, filter_types=None, filter_names=None):
         transform = self.__get_transform()
         docstrings = self.__parse(filename)
 
-        for docstr in docstrings.recursive_walk():
+        for docstr in docstrings.recursive_walk(filter_types=filter_types, filter_names=filter_names):
             lineoffset = docstr.get_line() - 1
             lines = statemachine.string2lines(docstr.get_docstring(transform=transform), 8,
                                               convert_whitespace=True)

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -28,10 +28,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
-class CAutoDocDirective(SphinxDirective):
-    """Extract all documentation comments from the specified file"""
-    required_arguments = 1
-    optional_arguments = 100 # arbitrary limit
+class CAutoBaseDirective(SphinxDirective):
     logger = logging.getLogger(__name__)
 
     option_spec = {
@@ -101,23 +98,6 @@ class CAutoDocDirective(SphinxDirective):
         # Note: None is a valid value for no transformation.
         return transformations.get(tropt)
 
-    def __get_filenames(self):
-        for pattern in self.arguments:
-            filenames = glob.glob(self.env.config.cautodoc_root + '/' + pattern)
-            if len(filenames) == 0:
-                self.logger.warning(f'Pattern "{pattern}" does not match any files.',
-                                    location=(self.env.docname, self.lineno))
-                continue
-
-            for filename in filenames:
-                mode = os.stat(filename).st_mode
-                if stat.S_ISDIR(mode):
-                    self.logger.warning(f'Path "{filename}" matching pattern "{pattern}" is a directory.',
-                                        location=(self.env.docname, self.lineno))
-                    continue
-
-                yield os.path.abspath(filename)
-
     def __parse(self, filename):
         clang_args = self.__get_clang_args()
 
@@ -156,7 +136,7 @@ class CAutoDocDirective(SphinxDirective):
     def run(self):
         result = ViewList()
 
-        for filename in self.__get_filenames():
+        for filename in self._get_filenames():
             self.__get_docstrings(result, filename)
 
         # Parse the extracted reST
@@ -165,6 +145,30 @@ class CAutoDocDirective(SphinxDirective):
             nested_parse_with_titles(self.state, result, node)
 
         return node.children
+
+class CAutoDocDirective(CAutoBaseDirective):
+    """Extract all documentation comments from the specified files"""
+
+    # Allow passing a variable number of file patterns as arguments
+    required_arguments = 1
+    optional_arguments = 100 # arbitrary limit
+
+    def _get_filenames(self):
+        for pattern in self.arguments:
+            filenames = glob.glob(self.env.config.cautodoc_root + '/' + pattern)
+            if len(filenames) == 0:
+                self.logger.warning(f'Pattern "{pattern}" does not match any files.',
+                                    location=(self.env.docname, self.lineno))
+                continue
+
+            for filename in filenames:
+                mode = os.stat(filename).st_mode
+                if stat.S_ISDIR(mode):
+                    self.logger.warning(f'Path "{filename}" matching pattern "{pattern}" is a directory.',
+                                        location=(self.env.docname, self.lineno))
+                    continue
+
+                yield os.path.abspath(filename)
 
 def setup(app):
     app.require_sphinx('3.0')

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -121,12 +121,23 @@ class CAutoDocDirective(SphinxDirective):
     def __parse(self, filename):
         clang_args = self.__get_clang_args()
 
+        # Cached parse results per rst document
+        parsed_files = self.env.temp_data.setdefault('cautodoc_parsed_files', {})
+
+        # The output depends on clang args
+        key = (filename, tuple(clang_args))
+
+        if key in parsed_files:
+            return parsed_files[key]
+
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
 
         docstrings, errors = parse(filename, clang=clang_args)
 
         self.__display_parser_diagnostics(errors)
+
+        parsed_files[key] = docstrings
 
         return docstrings
 

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -34,7 +34,7 @@ def main():
 
     transform = lambda comment: doccompat.convert(comment, transform=args.compat)
 
-    comments, errors = parse(args.file, clang=args.clang)
+    comments, errors = parse(args.file, clang_args=args.clang)
 
     for comment in comments.recursive_walk():
         if args.verbose:

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -8,9 +8,10 @@ class Docstring():
     _indent = 0
     _fmt = ''
 
-    def __init__(self, text=None, name=None, ttype=None, args=None, meta=None, nest=0):
+    def __init__(self, text=None, name=None, decl_name=None, ttype=None, args=None, meta=None, nest=0):
         self._text = text
         self._name = name
+        self._decl_name = decl_name if decl_name else name
         self._ttype = ttype
         self._args = args
         self._meta = meta
@@ -93,7 +94,7 @@ class Docstring():
 
         args = ', '.join(self._args) if self._args is not None else None
 
-        rst = self._fmt.format(text=text, name=self._name, ttype=self._ttype, args=args)
+        rst = self._fmt.format(text=text, name=self._decl_name, ttype=self._ttype, args=args)
 
         rst = Docstring._nest(rst, self._nest)
 
@@ -103,7 +104,6 @@ class Docstring():
         return self._meta
 
     def get_name(self):
-        # FIXME: This needs to return the pretty name.
         return self._name
 
     def get_line(self):

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -23,7 +23,20 @@ class Docstring():
     def add_children(self, comments):
         self._children.extend(comments)
 
-    def recursive_walk(self):
+    def _match(self, filter_types=None, filter_names=None):
+        if filter_types and type(self) not in filter_types:
+            return False
+
+        if filter_names and self.get_name() not in filter_names:
+            return False
+
+        return True
+
+    def recursive_walk(self, filter_types=None, filter_names=None):
+        # Note: The filtering is pretty specialized for our use case here. It
+        # only filters the immediate children, not this comment, nor
+        # grandchildren.
+
         # The contents of the parent will always be before children.
         if self._text:
             yield self
@@ -31,7 +44,8 @@ class Docstring():
         # Sort the children by order of appearance. We may add other sort
         # options later.
         for comment in sorted(self._children, key=lambda c: c.get_line()):
-            yield from comment.recursive_walk()
+            if comment._match(filter_types=filter_types, filter_names=filter_names):
+                yield from comment.recursive_walk()
 
     @staticmethod
     def is_doc(comment):
@@ -87,6 +101,10 @@ class Docstring():
 
     def get_meta(self):
         return self._meta
+
+    def get_name(self):
+        # FIXME: This needs to return the pretty name.
+        return self._name
 
     def get_line(self):
         return self._meta['line']

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -198,12 +198,13 @@ def _recursive_parse(comments, cursor, nest):
         return [ds]
 
     elif cursor.kind in [CursorKind.VAR_DECL, CursorKind.FIELD_DECL]:
-        ttype, name = _name_fixup(ttype, name)
+        # Note: Preserve original name
+        ttype, decl_name = _name_fixup(ttype, name)
 
         if cursor.kind == CursorKind.VAR_DECL:
-            ds = VarDocstring(text=text, nest=nest, name=name, ttype=ttype, meta=meta)
+            ds = VarDocstring(text=text, nest=nest, name=name, decl_name=decl_name, ttype=ttype, meta=meta)
         else:
-            ds = MemberDocstring(text=text, nest=nest, name=name, ttype=ttype, meta=meta)
+            ds = MemberDocstring(text=text, nest=nest, name=name, decl_name=decl_name, ttype=ttype, meta=meta)
 
         return [ds]
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -42,7 +42,6 @@ from clang.cindex import Index, TranslationUnit
 from clang.cindex import SourceLocation, SourceRange
 from clang.cindex import TokenKind, TokenGroup
 
-from hawkmoth.util import strutil
 from hawkmoth.docstring import *
 
 class ErrorLevel(enum.Enum):
@@ -301,13 +300,10 @@ def clang_diagnostics(diagnostics):
     return errors
 
 # return a list of (comment, metadata) tuples
-# options - dictionary with directive options
-def parse(filename, **options):
-    args = strutil.args_as_list(options.get('clang'))
-
+def parse(filename, clang_args=[]):
     index = Index.create()
 
-    tu = index.parse(filename, args=args, options=
+    tu = index.parse(filename, args=clang_args, options=
                      TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
                      TranslationUnit.PARSE_SKIP_FUNCTION_BODIES)
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -285,7 +285,8 @@ def _recursive_parse(comments, cursor, nest):
 
     return [ds]
 
-def clang_diagnostics(errors, diagnostics):
+def clang_diagnostics(diagnostics):
+    errors = []
     sev = {0: ErrorLevel.DEBUG,
            1: ErrorLevel.DEBUG,
            2: ErrorLevel.WARNING,
@@ -297,11 +298,11 @@ def clang_diagnostics(errors, diagnostics):
         errors.extend([(sev[diag.severity], filename,
                         diag.location.line, diag.spelling)])
 
+    return errors
+
 # return a list of (comment, metadata) tuples
 # options - dictionary with directive options
 def parse(filename, **options):
-
-    errors = []
     args = strutil.args_as_list(options.get('clang'))
 
     index = Index.create()
@@ -310,7 +311,7 @@ def parse(filename, **options):
                      TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
                      TranslationUnit.PARSE_SKIP_FUNCTION_BODIES)
 
-    clang_diagnostics(errors, tu.diagnostics)
+    errors = clang_diagnostics(tu.diagnostics)
 
     top_level_comments, comments = comment_extract(tu)
 

--- a/test/autovariable-fnptr-array.c
+++ b/test/autovariable-fnptr-array.c
@@ -1,0 +1,1 @@
+variable.c

--- a/test/autovariable-fnptr-array.rst
+++ b/test/autovariable-fnptr-array.rst
@@ -1,0 +1,5 @@
+
+.. c:var::  void (*function_pointer_array[5])(void)
+
+   array of function pointers
+

--- a/test/autovariable-fnptr-array.yaml
+++ b/test/autovariable-fnptr-array.yaml
@@ -1,0 +1,3 @@
+directive: autovar
+directive-arguments: function_pointer_array
+expected-failure: true

--- a/test/autovariable-fnptr-array.yaml
+++ b/test/autovariable-fnptr-array.yaml
@@ -1,3 +1,2 @@
 directive: autovar
 directive-arguments: function_pointer_array
-expected-failure: true

--- a/test/example-11-automacro.c
+++ b/test/example-11-automacro.c
@@ -1,0 +1,1 @@
+example-10-macro.c

--- a/test/example-11-automacro.rst
+++ b/test/example-11-automacro.rst
@@ -1,0 +1,7 @@
+
+.. c:macro:: DIE()
+
+   Terminate immediately with failure status.
+
+   See :c:macro:`FAILURE`.
+

--- a/test/example-11-automacro.yaml
+++ b/test/example-11-automacro.yaml
@@ -1,0 +1,2 @@
+directive: automacro
+directive-arguments: DIE

--- a/test/example-21-autovar.c
+++ b/test/example-21-autovar.c
@@ -1,0 +1,1 @@
+example-20-variable.c

--- a/test/example-21-autovar.rst
+++ b/test/example-21-autovar.rst
@@ -1,0 +1,5 @@
+
+.. c:var:: const int meaning_of_life
+
+   The name says it all.
+

--- a/test/example-21-autovar.yaml
+++ b/test/example-21-autovar.yaml
@@ -1,0 +1,2 @@
+directive: autovar
+directive-arguments: meaning_of_life

--- a/test/example-31-autotype.c
+++ b/test/example-31-autotype.c
@@ -1,0 +1,1 @@
+example-30-typedef.c

--- a/test/example-31-autotype.rst
+++ b/test/example-31-autotype.rst
@@ -1,0 +1,5 @@
+
+.. c:type:: list_data_t
+
+   Typedef documentation.
+

--- a/test/example-31-autotype.yaml
+++ b/test/example-31-autotype.yaml
@@ -1,0 +1,2 @@
+directive: autotype
+directive-arguments: list_data_t

--- a/test/example-41-autoenum.c
+++ b/test/example-41-autoenum.c
@@ -1,0 +1,1 @@
+example-40-enum.c

--- a/test/example-41-autoenum.rst
+++ b/test/example-41-autoenum.rst
@@ -1,0 +1,15 @@
+
+.. c:enum:: mode
+
+   Frobnication modes for :c:func:`frob`.
+
+
+   .. c:enumerator:: MODE_PRIMARY
+
+      The primary frobnication mode.
+
+
+   .. c:enumerator:: MODE_SECONDARY
+
+      The secondary frobnication mode.
+

--- a/test/example-41-autoenum.yaml
+++ b/test/example-41-autoenum.yaml
@@ -1,0 +1,2 @@
+directive: autoenum
+directive-arguments: mode

--- a/test/example-51-autostruct.c
+++ b/test/example-51-autostruct.c
@@ -1,0 +1,1 @@
+example-50-struct.c

--- a/test/example-51-autostruct.rst
+++ b/test/example-51-autostruct.rst
@@ -1,0 +1,15 @@
+
+.. c:struct:: list
+
+   Linked list node.
+
+
+   .. c:member:: struct list * next
+
+      Next node.
+
+
+   .. c:member:: int data
+
+      Data.
+

--- a/test/example-51-autostruct.yaml
+++ b/test/example-51-autostruct.yaml
@@ -1,0 +1,2 @@
+directive: autostruct
+directive-arguments: list

--- a/test/example-70-preprocessor.yaml
+++ b/test/example-70-preprocessor.yaml
@@ -1,2 +1,3 @@
 directive-options:
-  clang: -DDEEP_THOUGHT
+  clang:
+  - -DDEEP_THOUGHT

--- a/test/example-71-autofunction.c
+++ b/test/example-71-autofunction.c
@@ -1,0 +1,1 @@
+example-70-function.c

--- a/test/example-71-autofunction.rst
+++ b/test/example-71-autofunction.rst
@@ -1,0 +1,10 @@
+
+.. c:function:: int frob(struct list * list, enum mode mode)
+
+   List frobnicator.
+
+   :param list: The list to frob.
+   :param mode: The frobnication mode.
+   :return: 0 on success, non-zero error code on error.
+   :since: v0.1
+

--- a/test/example-71-autofunction.yaml
+++ b/test/example-71-autofunction.yaml
@@ -1,0 +1,2 @@
+directive: autofunction
+directive-arguments: frob

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -14,11 +14,15 @@ def _get_output(input_filename, app, status, warning, output_suffix, **options):
     shutil.copyfile(input_filename,
                     testenv.modify_filename(input_filename, dir=app.srcdir))
 
+    directive = options.get('directive', 'autodoc')
+    arguments = options.get('directive-arguments', '')
+    sep = ' ' if arguments else ''
+
     options = options.get('directive-options', {})
 
     with open(os.path.join(app.srcdir, 'index.rst'), 'w') as f:
         source = os.path.basename(input_filename)
-        f.write(f'.. c:autodoc:: {source}\n')
+        f.write(f'.. c:{directive}:: {source}{sep}{arguments}\n')
         for key, value in options.items():
             f.write(f'   :{key}: {value}\n')
 

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -24,6 +24,8 @@ def _get_output(input_filename, app, status, warning, output_suffix, **options):
         source = os.path.basename(input_filename)
         f.write(f'.. c:{directive}:: {source}{sep}{arguments}\n')
         for key, value in options.items():
+            if isinstance(value, list):
+                value = ', '.join(value)
             f.write(f'   :{key}: {value}\n')
 
     app.build()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -44,6 +44,10 @@ def _capture(capsys):
 def _get_output(input_filename, monkeypatch, capsys, **options):
     args = [input_filename]
 
+    directive = options.get('directive')
+    if directive:
+        pytest.skip(f'{directive} directive test')
+
     options = options.get('directive-options', {})
 
     transform = options.get('compat', None)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,7 +8,6 @@ import re
 import pytest
 
 from hawkmoth.__main__ import main
-from hawkmoth.util import strutil
 from test import testenv
 
 # Mock sys.argv for cli
@@ -58,9 +57,9 @@ def _get_output(input_filename, monkeypatch, capsys, **options):
         if transform is not None:
             pytest.skip('cli does not support generic transformations')
 
-    clang = options.get('clang', None)
-    if clang:
-        args += [f'--clang={arg}' for arg in strutil.args_as_list(clang)]
+    clang_args = options.get('clang')
+    if clang_args:
+        args += [f'--clang={clang_arg}' for clang_arg in clang_args]
 
     _mock_args(monkeypatch, args)
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -20,6 +20,9 @@ def _get_output(input_filename, **options):
 
     options = options.get('directive-options', {})
 
+    clang_args = options.get('clang')
+    comments, errors = parse(input_filename, clang_args=clang_args)
+
     tropt = options.pop('compat', None)
     if tropt is not None:
         transform = lambda comment: doccompat.convert(comment, transform=tropt)
@@ -29,8 +32,6 @@ def _get_output(input_filename, **options):
             transform = conf.cautodoc_transformations[tropt]
         else:
             transform = None
-
-    comments, errors = parse(input_filename, **options)
 
     for comment in comments.recursive_walk():
         docs_str += comment.get_docstring(transform=transform) + '\n'

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -14,6 +14,10 @@ def _get_output(input_filename, **options):
     docs_str = ''
     errors_str = ''
 
+    directive = options.get('directive')
+    if directive:
+        pytest.skip(f'{directive} directive test')
+
     options = options.get('directive-options', {})
 
     tropt = options.pop('compat', None)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -28,7 +28,7 @@ options_schema = strictyaml.Map({
     strictyaml.Optional('directive'): strictyaml.Str(),
     strictyaml.Optional('directive-arguments'): strictyaml.Str(),
     strictyaml.Optional('directive-options'): strictyaml.Map({
-        strictyaml.Optional('clang'): strictyaml.Str(),
+        strictyaml.Optional('clang'): strictyaml.Seq(strictyaml.Str()),
         strictyaml.Optional('compat'): strictyaml.Str(),
         strictyaml.Optional('transform'): strictyaml.Str(),
     }),

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -25,6 +25,8 @@ def get_testcases(path):
             yield os.path.join(path, f)
 
 options_schema = strictyaml.Map({
+    strictyaml.Optional('directive'): strictyaml.Str(),
+    strictyaml.Optional('directive-arguments'): strictyaml.Str(),
     strictyaml.Optional('directive-options'): strictyaml.Map({
         strictyaml.Optional('clang'): strictyaml.Str(),
         strictyaml.Optional('compat'): strictyaml.Str(),

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -66,6 +66,8 @@ def print_example(testcase):
 
     directive_options_str = ''
     for key, value in options.items():
+        if isinstance(value, list):
+            value = ', '.join(value)
         directive_options_str += f':{key}: {value}\n'
     directive_options_str = directive_options_str.strip()
 

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -49,11 +49,11 @@ def print_example(testcase):
     title = get_title(testcase)
     basename = os.path.basename(testcase)
     input_filename = f'examples/{basename}'
-    options_dict = testenv.get_testcase_options(testcase).get('directive-options', {})
-    options = ''
-    for key, value in options_dict.items():
-        options += f':{key}: {value}\n'
-    options = options.strip()
+    options = testenv.get_testcase_options(testcase).get('directive-options', {})
+    directive_options_str = ''
+    for key, value in options.items():
+        directive_options_str += f':{key}: {value}\n'
+    directive_options_str = directive_options_str.strip()
 
     print(f'''{title}
 {get_title_underline(title)}
@@ -70,13 +70,13 @@ Directive
 .. code-block:: rest
 
    .. c:autodoc:: {input_filename}
-{indent(options, '      ')}
+{indent(directive_options_str, '      ')}
 
 Output
 ~~~~~~
 
 .. c:autodoc:: {input_filename}
-{indent(options, '   ')}
+{indent(directive_options_str, '   ')}
 ''')
 
 if __name__ == '__main__':

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -49,7 +49,14 @@ def print_example(testcase):
     title = get_title(testcase)
     basename = os.path.basename(testcase)
     input_filename = f'examples/{basename}'
-    options = testenv.get_testcase_options(testcase).get('directive-options', {})
+    options = testenv.get_testcase_options(testcase)
+
+    directive = options.get('directive', 'autodoc')
+    arguments = options.get('directive-arguments', '')
+    sep = ' ' if arguments else ''
+
+    options = options.get('directive-options', {})
+
     directive_options_str = ''
     for key, value in options.items():
         directive_options_str += f':{key}: {value}\n'
@@ -69,13 +76,13 @@ Directive
 
 .. code-block:: rest
 
-   .. c:autodoc:: {input_filename}
+   .. c:{directive}:: {input_filename}{sep}{arguments}
 {indent(directive_options_str, '      ')}
 
 Output
 ~~~~~~
 
-.. c:autodoc:: {input_filename}
+.. c:{directive}:: {input_filename}{sep}{arguments}
 {indent(directive_options_str, '   ')}
 ''')
 

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -51,7 +51,14 @@ def print_example(testcase):
     input_filename = f'examples/{basename}'
     options = testenv.get_testcase_options(testcase)
 
-    directive = options.get('directive', 'autodoc')
+    directive = options.get('directive')
+    if directive:
+        namespace_push = f'.. c:namespace-push:: {title}'
+        namespace_pop = '.. c:namespace-pop::'
+    else:
+        directive = 'autodoc'
+        namespace_push = ''
+        namespace_pop = ''
     arguments = options.get('directive-arguments', '')
     sep = ' ' if arguments else ''
 
@@ -82,8 +89,13 @@ Directive
 Output
 ~~~~~~
 
+{namespace_push}
+
 .. c:{directive}:: {input_filename}{sep}{arguments}
 {indent(directive_options_str, '   ')}
+
+{namespace_pop}
+
 ''')
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements the basic feature request in #51.

While there may still be some rough edges in the implementation and documentation, I think the design is pretty good, and I think it's a good starting point to expand on. I can envision the following follow-up feature requests will come pretty soon:

- There needs to be a way to not repeat the source file name every time.
- There needs to be a way to grab, say, all structs in a source file without specifying all of them.
- After you've included documentation for some of the things you want to highlight, there needs to be a way to grab all the rest without specifying all of them.

They are not all that difficult to implement on top, just need to get the directive syntax right. For now, it's simply

`.. c:autofunction filename.c function_name
`

for all of them.

@BrunoMSantos After getting the much appreciated review for the previous changes from you, this is how I reward you, with another big batch of changes. ;)
