### PR TITLE
Autodoc v3

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -39,7 +39,42 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-10-macro.c
+
+
+
+
+
+Automacro
+---------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-11-automacro.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:automacro:: DIE
+      :file: examples/example-11-automacro.c
+   
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Automacro
+
+.. c:automacro:: DIE
+   :file: examples/example-11-automacro.c
+
+
+.. c:namespace-pop::
 
 
 Variable
@@ -62,7 +97,42 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-20-variable.c
+
+
+
+
+
+Autovar
+-------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-21-autovar.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autovar:: meaning_of_life
+      :file: examples/example-21-autovar.c
+   
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autovar
+
+.. c:autovar:: meaning_of_life
+   :file: examples/example-21-autovar.c
+
+
+.. c:namespace-pop::
 
 
 Typedef
@@ -85,7 +155,42 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-30-typedef.c
+
+
+
+
+
+Autotype
+--------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-31-autotype.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autotype:: list_data_t
+      :file: examples/example-31-autotype.c
+   
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autotype
+
+.. c:autotype:: list_data_t
+   :file: examples/example-31-autotype.c
+
+
+.. c:namespace-pop::
 
 
 Enum
@@ -108,7 +213,44 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-40-enum.c
+
+
+
+
+
+Autoenum
+--------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-41-autoenum.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autoenum:: mode
+      :file: examples/example-41-autoenum.c
+      :members: 
+   
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autoenum
+
+.. c:autoenum:: mode
+   :file: examples/example-41-autoenum.c
+   :members: 
+
+
+.. c:namespace-pop::
 
 
 Struct
@@ -131,7 +273,44 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-50-struct.c
+
+
+
+
+
+Autostruct
+----------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-51-autostruct.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autostruct:: list
+      :file: examples/example-51-autostruct.c
+      :members: 
+   
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autostruct
+
+.. c:autostruct:: list
+   :file: examples/example-51-autostruct.c
+   :members: 
+
+
+.. c:namespace-pop::
 
 
 Function
@@ -154,7 +333,12 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-70-function.c
+
+
+
 
 
 Preprocessor
@@ -178,8 +362,43 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-70-preprocessor.c
    :clang: -DDEEP_THOUGHT
+
+
+
+
+
+Autofunction
+------------
+
+Source
+~~~~~~
+
+.. literalinclude:: examples/example-71-autofunction.c
+   :language: C
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autofunction:: frob
+      :file: examples/example-71-autofunction.c
+   
+
+Output
+~~~~~~
+
+.. c:namespace-push:: Autofunction
+
+.. c:autofunction:: frob
+   :file: examples/example-71-autofunction.c
+
+
+.. c:namespace-pop::
 
 
 Transform
@@ -203,8 +422,13 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-75-transform.c
    :transform: napoleon
+
+
+
 
 
 Compat
@@ -228,8 +452,13 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-80-compat.c
    :transform: javadoc-liberal
+
+
+
 
 
 Generic
@@ -252,6 +481,11 @@ Directive
 Output
 ~~~~~~
 
+
+
 .. c:autodoc:: examples/example-90-generic.c
+
+
+
 
 

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -3,7 +3,7 @@
 C Autodoc Extension
 ===================
 
-Hawkmoth provides a Sphinx extension that adds a new directive to the Sphinx
+Hawkmoth provides a Sphinx extension that adds new directives to the Sphinx
 :any:`C domain <sphinx:c-domain>` to incorporate formatted C source code
 comments into a document. Hawkmoth is Sphinx :any:`sphinx:sphinx.ext.autodoc`
 for C.
@@ -127,10 +127,13 @@ The extension has a few configuration options that can be set in ``conf.py``:
    You can also pass in the compiler to use, for example
    ``get_include_args('gcc')``.
 
-Directive
----------
+Directives
+----------
 
-This module provides the following new directive:
+Hawkmoth provides several new directives for incorporating documentation
+comments from C sources into the reStructuredText document. The
+:rst:dir:`c:autodoc` directive simply includes all the comments from any number
+of files, while the rest are for including documentation for specific symbols.
 
 .. rst:directive:: .. c:autodoc:: filename-pattern [...]
 
@@ -163,6 +166,56 @@ This module provides the following new directive:
       The ``clang`` option extends the :data:`cautodoc_clang` configuration
       option.
 
+.. rst:directive:: .. c:autovar:: name
+
+   .. rst:directive:option:: file
+      :type: text
+
+      The ``file`` option specifies to file to parse. The filename is
+      interpreted relative to the :data:`cautodoc_root` configuration
+      option. (For the time being, this option is mandatory.)
+
+   Incorporate the documentation comment for the variable ``name`` in the file
+   ``file``.
+
+.. rst:directive:: .. c:autotype:: name
+
+   Same as :rst:dir:`c:autovar` but for typedefs.
+
+.. rst:directive:: .. c:automacro:: name
+
+   Same as :rst:dir:`c:autovar` but for macros, including function-like macros.
+
+.. rst:directive:: .. c:autofunction:: name
+
+   Same as :rst:dir:`c:autovar` but for functions. (Use :rst:dir:`c:automacro`
+   for function-like macros.)
+
+.. rst:directive:: .. c:autostruct:: name
+
+   .. rst:directive:option:: members
+      :type: text
+
+      The ``members`` option specifies the struct members to include. If
+      ``members`` is not specified, do not include member documentation. If
+      ``members`` is specified without arguments, include all member
+      documentation recursively. If ``members`` is specified with a
+      comma-separated list of arguments, include all specified member
+      documentation recursively.
+
+   Same as :rst:dir:`c:autovar` but for structs. Additionally, filter by
+   ``members``.
+
+.. rst:directive:: .. c:autounion:: name
+
+   Same as :rst:dir:`c:autostruct` but for unions.
+
+.. rst:directive:: .. c:autoenum:: name
+
+   Same as :rst:dir:`c:autostruct` but for enums. The enumeration constants are
+   considered ``members`` and are filtered accordingly.
+
+
 Examples
 --------
 
@@ -171,6 +224,16 @@ The basic usage is:
 .. code-block:: rst
 
    .. c:autodoc:: interface.h
+
+Individual symbols:
+
+.. code-block:: rst
+
+   .. c:autofunction:: foo
+      :file: interface.h
+
+   .. c:autostruct:: bar
+      :file: interface.h
 
 Several files with compatibility and compiler options:
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -130,11 +130,11 @@ class CAutoDocDirective(SphinxDirective):
 
         return docstrings
 
-    def __get_docstrings(self, viewlist, filename):
+    def __get_docstrings(self, viewlist, filename, filter_types=None, filter_names=None):
         transform = self.__get_transform()
         docstrings = self.__parse(filename)
 
-        for docstr in docstrings.walk():
+        for docstr in docstrings.walk(filter_types=filter_types, filter_names=filter_names):
             lineoffset = docstr.get_line() - 1
             lines = statemachine.string2lines(docstr.get_docstring(transform=transform), 8,
                                               convert_whitespace=True)

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -23,6 +23,7 @@ from sphinx.util import logging
 
 from hawkmoth.parser import parse, ErrorLevel
 from hawkmoth.util import doccompat, strutil
+from hawkmoth import docstring
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
@@ -137,7 +138,7 @@ class CAutoBaseDirective(SphinxDirective):
         result = ViewList()
 
         for filename in self._get_filenames():
-            self.__get_docstrings(result, filename)
+            self.__get_docstrings(result, filename, self._docstring_types, self._get_names())
 
         # Parse the extracted reST
         with switch_source_input(self.state, result):
@@ -152,6 +153,8 @@ class CAutoDocDirective(CAutoBaseDirective):
     # Allow passing a variable number of file patterns as arguments
     required_arguments = 1
     optional_arguments = 100 # arbitrary limit
+
+    _docstring_types = None
 
     def _get_filenames(self):
         for pattern in self.arguments:
@@ -170,6 +173,61 @@ class CAutoDocDirective(CAutoBaseDirective):
 
                 yield os.path.abspath(filename)
 
+    def _get_names(self):
+        return None
+
+# Base class for named stuff
+class CAutoSymbolDirective(CAutoBaseDirective):
+    """Extract specified documentation comments from the specified file"""
+
+    required_arguments = 1
+    optional_arguments = 0
+
+    option_spec = CAutoBaseDirective.option_spec.copy()
+    option_spec.update({
+        'file': directives.unchanged_required,
+    })
+
+    _docstring_types = None
+
+    def _get_filenames(self):
+        filename = self.options.get('file')
+
+        # Note: For the time being the file option is mandatory (sic).
+        if not filename:
+            self.logger.warning(f':file: option missing.',
+                                location=(self.env.docname, self.lineno))
+            return []
+
+        return [os.path.abspath(os.path.join(self.env.config.cautodoc_root, filename))]
+
+    def _get_names(self):
+        return [self.arguments[0]]
+
+class CAutoVarDirective(CAutoSymbolDirective):
+    _docstring_types = [docstring.VarDocstring]
+
+class CAutoTypeDirective(CAutoSymbolDirective):
+    _docstring_types = [docstring.TypeDocstring]
+
+class CAutoMacroDirective(CAutoSymbolDirective):
+    _docstring_types = [docstring.MacroDocstring, docstring.MacroFunctionDocstring]
+
+class CAutoFunctionDirective(CAutoSymbolDirective):
+    _docstring_types = [docstring.FunctionDocstring]
+
+class CAutoCompoundDirective(CAutoSymbolDirective):
+    pass
+
+class CAutoStructDirective(CAutoCompoundDirective):
+    _docstring_types = [docstring.StructDocstring]
+
+class CAutoUnionDirective(CAutoCompoundDirective):
+    _docstring_types = [docstring.UnionDocstring]
+
+class CAutoEnumDirective(CAutoCompoundDirective):
+    _docstring_types = [docstring.EnumDocstring]
+
 def setup(app):
     app.require_sphinx('3.0')
     app.add_config_value('cautodoc_root', app.confdir, 'env', [str])
@@ -177,6 +235,13 @@ def setup(app):
     app.add_config_value('cautodoc_transformations', None, 'env', [dict])
     app.add_config_value('cautodoc_clang', [], 'env', [list])
     app.add_directive_to_domain('c', 'autodoc', CAutoDocDirective)
+    app.add_directive_to_domain('c', 'autovar', CAutoVarDirective)
+    app.add_directive_to_domain('c', 'autotype', CAutoTypeDirective)
+    app.add_directive_to_domain('c', 'autostruct', CAutoStructDirective)
+    app.add_directive_to_domain('c', 'autounion', CAutoUnionDirective)
+    app.add_directive_to_domain('c', 'autoenum', CAutoEnumDirective)
+    app.add_directive_to_domain('c', 'automacro', CAutoMacroDirective)
+    app.add_directive_to_domain('c', 'autofunction', CAutoFunctionDirective)
 
     return dict(version = __version__,
                 parallel_read_safe = True, parallel_write_safe = True)

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -28,10 +28,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
-class CAutoDocDirective(SphinxDirective):
-    """Extract all documentation comments from the specified file"""
-    required_arguments = 1
-    optional_arguments = 100 # arbitrary limit
+class CAutoBaseDirective(SphinxDirective):
     logger = logging.getLogger(__name__)
 
     option_spec = {
@@ -101,23 +98,6 @@ class CAutoDocDirective(SphinxDirective):
         # Note: None is a valid value for no transformation.
         return transformations.get(tropt)
 
-    def __get_filenames(self):
-        for pattern in self.arguments:
-            filenames = glob.glob(self.env.config.cautodoc_root + '/' + pattern)
-            if len(filenames) == 0:
-                self.logger.warning(f'Pattern "{pattern}" does not match any files.',
-                                    location=(self.env.docname, self.lineno))
-                continue
-
-            for filename in filenames:
-                mode = os.stat(filename).st_mode
-                if stat.S_ISDIR(mode):
-                    self.logger.warning(f'Path "{filename}" matching pattern "{pattern}" is a directory.',
-                                        location=(self.env.docname, self.lineno))
-                    continue
-
-                yield os.path.abspath(filename)
-
     def __parse(self, filename):
         clang_args = self.__get_clang_args()
 
@@ -156,7 +136,7 @@ class CAutoDocDirective(SphinxDirective):
     def run(self):
         result = ViewList()
 
-        for filename in self.__get_filenames():
+        for filename in self._get_filenames():
             self.__get_docstrings(result, filename)
 
         # Parse the extracted reST
@@ -165,6 +145,30 @@ class CAutoDocDirective(SphinxDirective):
             nested_parse_with_titles(self.state, result, node)
 
         return node.children
+
+class CAutoDocDirective(CAutoBaseDirective):
+    """Extract all documentation comments from the specified files"""
+
+    # Allow passing a variable number of file patterns as arguments
+    required_arguments = 1
+    optional_arguments = 100 # arbitrary limit
+
+    def _get_filenames(self):
+        for pattern in self.arguments:
+            filenames = glob.glob(self.env.config.cautodoc_root + '/' + pattern)
+            if len(filenames) == 0:
+                self.logger.warning(f'Pattern "{pattern}" does not match any files.',
+                                    location=(self.env.docname, self.lineno))
+                continue
+
+            for filename in filenames:
+                mode = os.stat(filename).st_mode
+                if stat.S_ISDIR(mode):
+                    self.logger.warning(f'Path "{filename}" matching pattern "{pattern}" is a directory.',
+                                        location=(self.env.docname, self.lineno))
+                    continue
+
+                yield os.path.abspath(filename)
 
 def setup(app):
     app.require_sphinx('3.0')

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -134,7 +134,7 @@ class CAutoDocDirective(SphinxDirective):
         transform = self.__get_transform()
         docstrings = self.__parse(filename)
 
-        for docstr in docstrings.recursive_walk():
+        for docstr in docstrings.walk():
             lineoffset = docstr.get_line() - 1
             lines = statemachine.string2lines(docstr.get_docstring(transform=transform), 8,
                                               convert_whitespace=True)

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -121,12 +121,23 @@ class CAutoDocDirective(SphinxDirective):
     def __parse(self, filename):
         clang_args = self.__get_clang_args()
 
+        # Cached parse results per rst document
+        parsed_files = self.env.temp_data.setdefault('cautodoc_parsed_files', {})
+
+        # The output depends on clang args
+        key = (filename, tuple(clang_args))
+
+        if key in parsed_files:
+            return parsed_files[key]
+
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
 
         docstrings, errors = parse(filename, clang_args=clang_args)
 
         self.__display_parser_diagnostics(errors)
+
+        parsed_files[key] = docstrings
 
         return docstrings
 

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -36,7 +36,7 @@ def main():
 
     comments, errors = parse(args.file, clang_args=args.clang)
 
-    for comment in comments.recursive_walk():
+    for comment in comments.walk():
         if args.verbose:
             print(f'# {comment.get_meta()}')
         print(comment.get_docstring(transform=transform))

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -44,7 +44,7 @@ class Docstring():
     def add_children(self, comments):
         self._children.extend(comments)
 
-    def recursive_walk(self):
+    def walk(self, recurse=True):
         # The contents of the parent will always be before children.
         if self._text:
             yield self
@@ -52,7 +52,10 @@ class Docstring():
         # Sort the children by order of appearance. We may add other sort
         # options later.
         for comment in sorted(self._children, key=lambda c: c.get_line()):
-            yield from comment.recursive_walk()
+            if recurse:
+                yield from comment.walk()
+            else:
+                yield comment
 
     @staticmethod
     def is_doc(comment):

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -44,7 +44,20 @@ class Docstring():
     def add_children(self, comments):
         self._children.extend(comments)
 
-    def walk(self, recurse=True):
+    def _match(self, filter_types=None, filter_names=None):
+        if filter_types is not None and type(self) not in filter_types:
+            return False
+
+        if filter_names is not None and self.get_name() not in filter_names:
+            return False
+
+        return True
+
+    def walk(self, recurse=True, filter_types=None, filter_names=None):
+        # Note: The filtering is pretty specialized for our use case here. It
+        # only filters the immediate children, not this comment, nor
+        # grandchildren.
+
         # The contents of the parent will always be before children.
         if self._text:
             yield self
@@ -52,10 +65,11 @@ class Docstring():
         # Sort the children by order of appearance. We may add other sort
         # options later.
         for comment in sorted(self._children, key=lambda c: c.get_line()):
-            if recurse:
-                yield from comment.walk()
-            else:
-                yield comment
+            if comment._match(filter_types=filter_types, filter_names=filter_names):
+                if recurse:
+                    yield from comment.walk()
+                else:
+                    yield comment
 
     @staticmethod
     def is_doc(comment):

--- a/test/autovariable-fnptr-array.c
+++ b/test/autovariable-fnptr-array.c
@@ -1,0 +1,1 @@
+variable.c

--- a/test/autovariable-fnptr-array.rst
+++ b/test/autovariable-fnptr-array.rst
@@ -1,0 +1,5 @@
+
+.. c:var::  void (*function_pointer_array[5])(void)
+
+   array of function pointers
+

--- a/test/autovariable-fnptr-array.yaml
+++ b/test/autovariable-fnptr-array.yaml
@@ -1,0 +1,4 @@
+directive: autovar
+directive-arguments: function_pointer_array
+directive-options:
+  file:

--- a/test/example-11-automacro.c
+++ b/test/example-11-automacro.c
@@ -1,0 +1,1 @@
+example-10-macro.c

--- a/test/example-11-automacro.rst
+++ b/test/example-11-automacro.rst
@@ -1,0 +1,7 @@
+
+.. c:macro:: DIE()
+
+   Terminate immediately with failure status.
+
+   See :c:macro:`FAILURE`.
+

--- a/test/example-11-automacro.yaml
+++ b/test/example-11-automacro.yaml
@@ -1,0 +1,4 @@
+directive: automacro
+directive-arguments: DIE
+directive-options:
+  file:

--- a/test/example-21-autovar.c
+++ b/test/example-21-autovar.c
@@ -1,0 +1,1 @@
+example-20-variable.c

--- a/test/example-21-autovar.rst
+++ b/test/example-21-autovar.rst
@@ -1,0 +1,5 @@
+
+.. c:var:: const int meaning_of_life
+
+   The name says it all.
+

--- a/test/example-21-autovar.yaml
+++ b/test/example-21-autovar.yaml
@@ -1,0 +1,4 @@
+directive: autovar
+directive-arguments: meaning_of_life
+directive-options:
+  file:

--- a/test/example-31-autotype.c
+++ b/test/example-31-autotype.c
@@ -1,0 +1,1 @@
+example-30-typedef.c

--- a/test/example-31-autotype.rst
+++ b/test/example-31-autotype.rst
@@ -1,0 +1,5 @@
+
+.. c:type:: list_data_t
+
+   Typedef documentation.
+

--- a/test/example-31-autotype.yaml
+++ b/test/example-31-autotype.yaml
@@ -1,0 +1,4 @@
+directive: autotype
+directive-arguments: list_data_t
+directive-options:
+  file:

--- a/test/example-41-autoenum.c
+++ b/test/example-41-autoenum.c
@@ -1,0 +1,1 @@
+example-40-enum.c

--- a/test/example-41-autoenum.rst
+++ b/test/example-41-autoenum.rst
@@ -1,0 +1,15 @@
+
+.. c:enum:: mode
+
+   Frobnication modes for :c:func:`frob`.
+
+
+   .. c:enumerator:: MODE_PRIMARY
+
+      The primary frobnication mode.
+
+
+   .. c:enumerator:: MODE_SECONDARY
+
+      The secondary frobnication mode.
+

--- a/test/example-41-autoenum.yaml
+++ b/test/example-41-autoenum.yaml
@@ -1,0 +1,5 @@
+directive: autoenum
+directive-arguments: mode
+directive-options:
+  file:
+  members:

--- a/test/example-51-autostruct.c
+++ b/test/example-51-autostruct.c
@@ -1,0 +1,1 @@
+example-50-struct.c

--- a/test/example-51-autostruct.rst
+++ b/test/example-51-autostruct.rst
@@ -1,0 +1,15 @@
+
+.. c:struct:: list
+
+   Linked list node.
+
+
+   .. c:member:: struct list * next
+
+      Next node.
+
+
+   .. c:member:: int data
+
+      Data.
+

--- a/test/example-51-autostruct.yaml
+++ b/test/example-51-autostruct.yaml
@@ -1,0 +1,5 @@
+directive: autostruct
+directive-arguments: list
+directive-options:
+  file:
+  members:

--- a/test/example-71-autofunction.c
+++ b/test/example-71-autofunction.c
@@ -1,0 +1,1 @@
+example-70-function.c

--- a/test/example-71-autofunction.rst
+++ b/test/example-71-autofunction.rst
@@ -1,0 +1,10 @@
+
+.. c:function:: int frob(struct list * list, enum mode mode)
+
+   List frobnicator.
+
+   :param list: The list to frob.
+   :param mode: The frobnication mode.
+   :return: 0 on success, non-zero error code on error.
+   :since: v0.1
+

--- a/test/example-71-autofunction.yaml
+++ b/test/example-71-autofunction.yaml
@@ -1,0 +1,4 @@
+directive: autofunction
+directive-arguments: frob
+directive-options:
+  file:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -43,6 +43,10 @@ def _capture(capsys):
 def _get_output(input_filename, monkeypatch, capsys, **options):
     args = [input_filename]
 
+    directive = options.get('directive')
+    if directive:
+        pytest.skip(f'{directive} directive test')
+
     options = options.get('directive-options', {})
 
     transform = options.get('compat', None)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -14,6 +14,10 @@ def _get_output(input_filename, **options):
     docs_str = ''
     errors_str = ''
 
+    directive = options.get('directive')
+    if directive:
+        pytest.skip(f'{directive} directive test')
+
     options = options.get('directive-options', {})
 
     clang_args = options.get('clang')

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -29,7 +29,7 @@ def _get_output(input_filename, **options):
         else:
             transform = None
 
-    for comment in comments.recursive_walk():
+    for comment in comments.walk():
         docs_str += comment.get_docstring(transform=transform) + '\n'
 
     for (severity, filename, lineno, msg) in errors:

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -51,6 +51,14 @@ def print_example(testcase):
     input_filename = f'examples/{basename}'
     options = testenv.get_testcase_options(testcase)
 
+    directive = options.get('directive')
+    if directive:
+        namespace_push = f'.. c:namespace-push:: {title}'
+        namespace_pop = '.. c:namespace-pop::'
+    else:
+        namespace_push = ''
+        namespace_pop = ''
+
     directive_str = testenv.get_directive_string(options, input_filename)
 
     print(f'''{title}
@@ -72,7 +80,12 @@ Directive
 Output
 ~~~~~~
 
+{namespace_push}
+
 {directive_str}
+
+{namespace_pop}
+
 ''')
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is the updated version of #61.

- The filename has been moved from directive argument to `:file:` directive option, which is, for the time being, mandatory. But as discussed, it can be made optional in the future.
- The composite types (and we liberally include enum here too) now have a `:members:` directive option similar to the Sphinx autodoc extension. There's a new base class for handling struct/union/enum directives.
- Overall better ordering of commits with most of the cleanups merged in #62.

Basic documentation and tests are there, but I think I'll want to revisit them. `:members:` testing is still missing. The documentation is probably confusing and the generated examples page is now a mess. I think I'll want to move most of the old `c:autodoc` examples to regular tests that don't show up in the examples page to reduce duplication.