### PR TITLE
Comment strip v2

### DIFF
--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -78,16 +78,20 @@ class Docstring():
 
     def _get_plain_comment(self):
         """Return plain comment with comment markers and line prefixes removed."""
-        comment = self._text
+        lines = self._text.splitlines()
 
-        comment = re.sub(r'^/\*\*[ \t]*', '', comment)
-        comment = re.sub(r'[ \t]*\*/$', '', comment)
-        # Could look at first line of comment, and remove the leading stuff there
-        # from the rest.
-        comment = re.sub(r'(?m)^[ \t]*\*?[ \t]?', '', comment)
-        # Strip leading blank lines.
-        comment = re.sub(r'^[\n]*', '', comment)
-        return comment.strip()
+        lines[0] = re.sub(r'^/\*\*[ \t]*', '', lines[0])
+        lines[-1] = re.sub(r'[ \t]*\*/$', '', lines[-1])
+
+        lines[1:-1] = [re.sub(r'^[ \t]*\*?[ \t]?', '', line) for line in lines[1:-1]]
+
+        while not lines[0] or lines[0].isspace():
+            del lines[0]
+
+        while not lines[-1] or lines[-1].isspace():
+            del lines[-1]
+
+        return '\n'.join(lines)
 
     @staticmethod
     def _nest(text, nest):

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -22,7 +22,26 @@ conversions:
 * Generation of Sphinx C Domain directives with appropriate indentation.
 """
 
+import os
 import re
+
+def _commonprefix_len(lines):
+    # common prefix
+    prefix = os.path.commonprefix(lines)
+
+    # common prefix length of limited characters
+    return len(prefix) - len(prefix.lstrip(' \t*'))
+
+def _get_prefix_len(lines):
+    # ignore lines with just space
+    lines = [line for line in lines if line.strip()]
+    prefix_len = _commonprefix_len(lines)
+
+    # ignore lines with just the prefix and space
+    lines = [line for line in lines if line[prefix_len:].strip()]
+    prefix_len = _commonprefix_len(lines)
+
+    return prefix_len
 
 class Docstring():
     _indent = 0
@@ -83,7 +102,8 @@ class Docstring():
         lines[0] = re.sub(r'^/\*\*[ \t]*', '', lines[0])
         lines[-1] = re.sub(r'[ \t]*\*/$', '', lines[-1])
 
-        lines[1:-1] = [re.sub(r'^[ \t]*\*?[ \t]?', '', line) for line in lines[1:-1]]
+        prefix_len = _get_prefix_len(lines[1:-1])
+        lines[1:-1] = [line[prefix_len:] for line in lines[1:-1]]
 
         while not lines[0] or lines[0].isspace():
             del lines[0]

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -80,8 +80,8 @@ class Docstring():
         """Return plain comment with comment markers and line prefixes removed."""
         comment = self._text
 
-        comment = re.sub(r'^/\*\*[ \t]?', '', comment)
-        comment = re.sub(r'\*/$', '', comment)
+        comment = re.sub(r'^/\*\*[ \t]*', '', comment)
+        comment = re.sub(r'[ \t]*\*/$', '', comment)
         # Could look at first line of comment, and remove the leading stuff there
         # from the rest.
         comment = re.sub(r'(?m)^[ \t]*\*?[ \t]?', '', comment)

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -76,9 +76,10 @@ class Docstring():
         """Test if comment is a C documentation comment."""
         return comment.startswith('/**') and comment != '/**/'
 
-    @staticmethod
-    def _strip(comment):
-        """Strip comment from comment markers."""
+    def _get_plain_comment(self):
+        """Return plain comment with comment markers and line prefixes removed."""
+        comment = self._text
+
         comment = re.sub(r'^/\*\*[ \t]?', '', comment)
         comment = re.sub(r'\*/$', '', comment)
         # Could look at first line of comment, and remove the leading stuff there
@@ -108,7 +109,7 @@ class Docstring():
         # error reporting via meta['line']. Adjust meta to take this into
         # account.
 
-        text = Docstring._strip(self._text)
+        text = self._get_plain_comment()
 
         if transform is not None:
             text = transform(text)

--- a/test/comment-strip.c
+++ b/test/comment-strip.c
@@ -1,0 +1,109 @@
+/**
+ * Recommended formatting.
+ *
+ * :param foo: foo
+ *   continuation with spaces
+ * :param bar: bar
+ *   continuation with spaces
+ */
+int space_star_space(int foo, int bar);
+
+/**
+No prefix at all.
+
+:param foo: foo
+  continuation with spaces
+:param bar: bar
+  continuation with spaces
+*/
+int no_prefix(int foo, int bar);
+
+/**
+    Prefix with spaces.
+
+    :param foo: foo
+      continuation with spaces
+    :param bar: bar
+      continuation with spaces
+*/
+int space_prefix(int foo, int bar);
+
+/**
+	Tab prefix.
+
+	:param foo: foo
+		continuation with tab
+	:param foo: bar
+		continuation with tab
+*/
+int tab(int foo, int bar);
+
+/**	Tab prefix, content on first line.
+
+	:param foo: foo
+		continuation with tab
+	:param foo: bar
+		continuation with tab
+*/
+int tab_first_line_content(int foo, int bar);
+
+/** Not recommended.
+ *
+ * :param foo: foo
+ *   continuation with spaces
+ * :param bar: bar
+ *   continuation with spaces
+ */
+int space_star_space_first_line_content(int foo, int bar);
+
+/**
+ *Not recommended.
+ *
+ *:param foo: foo
+ *  continuation with spaces
+ *:param bar: bar
+ *  continuation with spaces
+ */
+int space_star(int foo, int bar);
+
+/**
+No prefix, bulleted list:
+
+* Bullet foo.
+* Bullet bar.
+*/
+int no_prefix_star_bullets(int foo, int bar);
+
+/**
+ * Normal, bulleted list:
+ *
+ * * Bullet foo.
+ * * Bullet bar.
+ */
+int space_star_space_star_bullets(int foo, int bar);
+
+/**
+ *	
+ *   
+ * 
+ * Leading and trailing blank line removal.
+ *	
+ *   
+ * 
+ */
+int blank_lines(int foo, int bar);
+
+/** One line comment. */
+int one_liner(int foo, int bar);
+
+/** 	 One line comment with leading and trailing whitespace.  	 */
+int one_liner_whitespace(int foo, int bar);
+
+/** Two line comment.
+ */
+int two_liner(int foo, int bar);
+
+/** 	 Two line comment with leading and trailing whitespace.
+ 	 */
+int two_liner_whitespace(int foo, int bar);
+

--- a/test/comment-strip.rst
+++ b/test/comment-strip.rst
@@ -1,0 +1,111 @@
+
+.. c:function:: int space_star_space(int foo, int bar)
+
+   Recommended formatting.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. c:function:: int no_prefix(int foo, int bar)
+
+   No prefix at all.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. c:function:: int space_prefix(int foo, int bar)
+
+   Prefix with spaces.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. c:function:: int tab(int foo, int bar)
+
+   Tab prefix.
+
+   :param foo: foo
+   	continuation with tab
+   :param foo: bar
+   	continuation with tab
+
+
+.. c:function:: int tab_first_line_content(int foo, int bar)
+
+   Tab prefix, content on first line.
+
+   :param foo: foo
+   	continuation with tab
+   :param foo: bar
+   	continuation with tab
+
+
+.. c:function:: int space_star_space_first_line_content(int foo, int bar)
+
+   Not recommended.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. c:function:: int space_star(int foo, int bar)
+
+   Not recommended.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. c:function:: int no_prefix_star_bullets(int foo, int bar)
+
+   No prefix, bulleted list:
+
+   * Bullet foo.
+   * Bullet bar.
+
+
+.. c:function:: int space_star_space_star_bullets(int foo, int bar)
+
+   Normal, bulleted list:
+
+   * Bullet foo.
+   * Bullet bar.
+
+
+.. c:function:: int blank_lines(int foo, int bar)
+
+   Leading and trailing blank line removal.
+
+
+.. c:function:: int one_liner(int foo, int bar)
+
+   One line comment.
+
+
+.. c:function:: int one_liner_whitespace(int foo, int bar)
+
+   One line comment with leading and trailing whitespace.
+
+
+.. c:function:: int two_liner(int foo, int bar)
+
+   Two line comment.
+
+
+.. c:function:: int two_liner_whitespace(int foo, int bar)
+
+   Two line comment with leading and trailing whitespace.
+

--- a/test/comment-strip.yaml
+++ b/test/comment-strip.yaml
@@ -1,0 +1,2 @@
+directive-arguments:
+- comment-strip.c

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -96,5 +96,5 @@ def run_test(input_filename, get_output, get_expected, monkeypatch=None, capsys=
     output_docs, output_errors = get_output(input_filename, monkeypatch=monkeypatch, capsys=capsys, **options)
     expect_docs, expect_errors = get_expected(input_filename, monkeypatch=monkeypatch, capsys=capsys, **options)
 
-    assert expect_docs == output_docs
-    assert expect_errors == output_errors
+    assert output_docs == expect_docs
+    assert output_errors == expect_errors


### PR DESCRIPTION
Rebase of #66, with `comment-strip.yaml` now added as that's required since #65.
