### PR TITLE
test: parallel testing with pytest-xdist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-xdist
 sphinx
 sphinx-testing
 strictyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ packages =
 [options.extras_require]
 dev =
     pytest
+    pytest-xdist
     sphinx-testing
     strictyaml
 

--- a/test/Makefile.local
+++ b/test/Makefile.local
@@ -6,7 +6,7 @@ test_dir := test
 
 .PHONY: test
 test:
-	pytest $(test_dir)
+	pytest -n auto $(test_dir)
 
 quick-test:
-	pytest -m "not full" $(test_dir)
+	pytest -n auto -m "not full" $(test_dir)


### PR DESCRIPTION
Using the development dependency pytest-xdist, 'time make test' drops to
about half on my machine.