### PR TITLE
Fix anonymous type detection for newer Clang version

### DIFF
--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -177,7 +177,7 @@ def _anonymous_fixup(ttype, name):
     if name:
         return ttype, name
 
-    mo = re.match(r'(?a)^(?P<type>enum|struct|union) ([^:]+::)?\(anonymous at [^)]+\)$', ttype)
+    mo = re.match(r'(?a)^(?P<type>enum|struct|union) ([^:]+::)?\((anonymous|unnamed) at [^)]+\)$', ttype)
     if mo:
         # Anonymous
         name = ''


### PR DESCRIPTION
Clang 13 introduces a change to the anonymous type names forcing us to
update the regex to support both versions.