### PR TITLE
change clang _Bool to more readable bool

### DIFF
--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -170,6 +170,8 @@ def _decl_fixup(ttype, name):
 
     ttype, name = _function_pointer_fixup(ttype, name)
 
+    if ttype == '_Bool': ttype = 'bool'
+
     return ttype, name
 
 # name may be empty for typedefs and anonymous enums, structs and unions


### PR DESCRIPTION
when declare with bool, clang auto change it to _Bool.