### PR TITLE
Add parameter names to function pointer variables and members

### DIFF
--- a/test/autostruct.rst
+++ b/test/autostruct.rst
@@ -13,6 +13,12 @@
 
    .. c:member::  int (*function_pointer_member)(int, int)
 
-      function pointer member
+      function pointer member with parameter names omitted
 
 
+   .. c:member::  int (*other_function_pointer_member)(int foo, int bar)
+
+      function pointer member with parameter names
+
+      :param foo: the foo
+      :param bar: the bar

--- a/test/autostruct.yaml
+++ b/test/autostruct.yaml
@@ -6,3 +6,4 @@ directive-options:
   members:
   - array_member
   - function_pointer_member
+  - other_function_pointer_member

--- a/test/function.rst
+++ b/test/function.rst
@@ -26,7 +26,7 @@
    Clang removes spaces.
 
 
-.. c:function:: void function_pointer_param( void *(*hook)(void *, int))
+.. c:function:: void function_pointer_param( void * (*hook)(void * p, int n))
 
    Function pointer parameter.
 

--- a/test/struct.c
+++ b/test/struct.c
@@ -17,9 +17,16 @@ struct sample_struct {
 	 */
 	void *pointer_member;
 	/**
-	 * function pointer member
+	 * function pointer member with parameter names omitted
 	 */
 	int (*function_pointer_member)(int, int);
+	/**
+	 * function pointer member with parameter names
+	 *
+	 * :param foo: the foo
+	 * :param bar: the bar
+	 */
+	int (*other_function_pointer_member)(int foo, int bar);
 	/**
 	 * foo next
 	 */

--- a/test/struct.rst
+++ b/test/struct.rst
@@ -23,7 +23,15 @@
 
    .. c:member::  int (*function_pointer_member)(int, int)
 
-      function pointer member
+      function pointer member with parameter names omitted
+
+
+   .. c:member::  int (*other_function_pointer_member)(int foo, int bar)
+
+      function pointer member with parameter names
+
+      :param foo: the foo
+      :param bar: the bar
 
 
    .. c:member:: struct sample_struct * next

--- a/test/variable.c
+++ b/test/variable.c
@@ -9,6 +9,11 @@ static int sheesh;
 int (*function_pointer_variable)(int *param_name_ignored);
 
 /**
+ * variadic function pointer variable
+ */
+int (*variadic_function_pointer_variable)(int *param_name_ignored, ...);
+
+/**
  * pointer to function pointer variable
  */
 int (**pointer_to_function_pointer_variable)(int);
@@ -19,9 +24,29 @@ int (**pointer_to_function_pointer_variable)(int);
 void (*function_pointer_array[5])(void);
 
 /**
+ * array of array of function pointers
+ */
+void (*array_of_function_pointer_array[5][15])(void);
+
+/**
  * function pointer with lots of const qualifiers
  */
 const char* (*const function_pointer_with_qualifier)(const char *in);
+
+/**
+ * function pointer with multiple qualifiers
+ */
+const char* (*const volatile function_pointer_with_multiple_qualifiers)(const char *in);
+
+/**
+ * a complex type involving function pointers somehow
+ */
+const char* (*const *volatile *restrict legal_type_involving_function_pointer[12][3])(const char *in);
+
+/**
+ * function pointer to a function taking a function pointer as arg
+ */
+int (*function_pointer_with_function_pointer_arg)(float (*arg1)(char c));
 
 /**
  * Array of pointers.

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -4,9 +4,14 @@
    This is a variable document.
 
 
-.. c:var::  int (*function_pointer_variable)(int *)
+.. c:var::  int (*function_pointer_variable)(int * param_name_ignored)
 
    function pointer variable
+
+
+.. c:var::  int (*variadic_function_pointer_variable)(int * param_name_ignored, ...)
+
+   variadic function pointer variable
 
 
 .. c:var::  int (**pointer_to_function_pointer_variable)(int)
@@ -19,9 +24,29 @@
    array of function pointers
 
 
-.. c:var::  const char *(*const function_pointer_with_qualifier)(const char *)
+.. c:var::  void (*array_of_function_pointer_array[5][15])(void)
+
+   array of array of function pointers
+
+
+.. c:var::  const char * (*const function_pointer_with_qualifier)(const char * in)
 
    function pointer with lots of const qualifiers
+
+
+.. c:var::  const char * (*const volatile function_pointer_with_multiple_qualifiers)(const char * in)
+
+   function pointer with multiple qualifiers
+
+
+.. c:var::  const char * (*const *volatile *restrict legal_type_involving_function_pointer[12][3])(const char * in)
+
+   a complex type involving function pointers somehow
+
+
+.. c:var::  int (*function_pointer_with_function_pointer_arg)( float (*arg1)(char c))
+
+   function pointer to a function taking a function pointer as arg
 
 
 .. c:var:: char * array_of_pointers[1]


### PR DESCRIPTION
Hi there, here's an implementation tentative to address issue #69
It may not meet the project's standards but hopefully it's something I can improve with your guidance.

I removed the regex parsing of the function pointer type and instead rely on clang's AST to rebuild the function signature, with names if available.

- Parameter names (and types) can be found in the children of the function pointer decl cursor.
- The associated FUNCTION_PROTO is used to find out about variadic function
- While traversing Type nodes to lookup the FUNCTION_PROTO I also accumulate required bits to rebuild function parameter declaration (constant array sizes and pointer qualifiers)

I also added a few tests to cover new use cases, although i could add a few more.
Tests run ok, except a few ones involving anonymous structs, the id appended to the anonymous structs is different from what's expected.
