### PR TITLE
Cleanup formatting

### DIFF
--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -146,12 +146,17 @@ class Docstring():
 
         ttype = self._ttype
 
+        spacer = ''
+        if ttype and not (len(ttype) == 0 or ttype.endswith('*')):
+            spacer = ' '
+
         args = ''
         if self._args and len(self._args) > 0:
             arg_fmt = lambda t, n: f"{t}{'' if len(t) == 0 or t.endswith('*') else ' '}{n}"
             args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
-        rst = self._fmt.format(text=text, name=self._get_decl_name(), ttype=self._ttype, args=args)
+        rst = self._fmt.format(text=text, name=name, ttype=ttype,
+                               type_spacer=spacer, args=args)
 
         rst = Docstring._nest(rst, self._nest)
 
@@ -175,7 +180,7 @@ class TextDocstring(Docstring):
 
 class VarDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:var:: {ttype} {name}\n\n{text}\n'
+    _fmt = '\n.. c:var:: {ttype}{type_spacer}{name}\n\n{text}\n'
 
 class TypeDocstring(Docstring):
     _indent = 1
@@ -211,7 +216,7 @@ class EnumeratorDocstring(Docstring):
 
 class MemberDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:member:: {ttype} {name}\n\n{text}\n'
+    _fmt = '\n.. c:member:: {ttype}{type_spacer}{name}\n\n{text}\n'
 
 class MacroDocstring(Docstring):
     _indent = 1
@@ -223,4 +228,4 @@ class MacroFunctionDocstring(Docstring):
 
 class FunctionDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:function:: {ttype} {name}({args})\n\n{text}\n'
+    _fmt = '\n.. c:function:: {ttype}{type_spacer}{name}({args})\n\n{text}\n'

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-2021 Jani Nikula <jani@nikula.org>
-# Copyright (c) 2018-2020 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
+# Copyright (c) 2018-2022 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 """
 Documentation comment storage and converter
@@ -142,7 +142,14 @@ class Docstring():
 
         text = Docstring._nest(text, self._indent)
 
-        args = ', '.join(self._args) if self._args is not None else None
+        name = self._get_decl_name()
+
+        ttype = self._ttype
+
+        args = ''
+        if self._args and len(self._args) > 0:
+            arg_fmt = lambda t, n: f"{t}{'' if len(t) == 0 or t.endswith('*') else ' '}{n}"
+            args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
         rst = self._fmt.format(text=text, name=self._get_decl_name(), ttype=self._ttype, args=args)
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-2017 Jani Nikula <jani@nikula.org>
-# Copyright (c) 2018-2020 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
+# Copyright (c) 2018-2022 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 """
 Documentation comment extractor
@@ -129,9 +129,9 @@ def _get_macro_args(cursor):
         elif token.spelling == ',':
             continue
         elif token.kind == TokenKind.IDENTIFIER:
-            args.append(token.spelling)
+            args.extend([('', token.spelling)])
         elif token.spelling == '...':
-            args.append(token.spelling)
+            args.extend([('', token.spelling)])
         else:
             break
 
@@ -275,11 +275,10 @@ def _recursive_parse(comments, cursor, nest):
             for c in cursor.get_children():
                 if c.kind == CursorKind.PARM_DECL:
                     arg_ttype, arg_name = _decl_fixup(c.type.spelling, c.spelling)
-
-                    args.append(f'{arg_ttype} {arg_name}')
+                    args.extend([(arg_ttype, arg_name)])
 
             if cursor.type.is_function_variadic():
-                args.append('...')
+                args.extend([('', '...')])
 
         ttype = cursor.result_type.spelling
 

--- a/test/example-20-variable.rst
+++ b/test/example-20-variable.rst
@@ -4,7 +4,7 @@
    The name says it all.
 
 
-.. c:var:: struct list * entries
+.. c:var:: struct list *entries
 
    The list of entries.
 

--- a/test/example-50-struct.rst
+++ b/test/example-50-struct.rst
@@ -4,7 +4,7 @@
    Linked list node.
 
 
-   .. c:member:: struct list * next
+   .. c:member:: struct list *next
 
       Next node.
 

--- a/test/example-70-function.rst
+++ b/test/example-70-function.rst
@@ -1,5 +1,5 @@
 
-.. c:function:: int frob(struct list * list, enum mode mode)
+.. c:function:: int frob(struct list *list, enum mode mode)
 
    List frobnicator.
 
@@ -9,7 +9,7 @@
    :since: v0.1
 
 
-.. c:function:: int frobo(const char * fmt, ...)
+.. c:function:: int frobo(const char *fmt, ...)
 
    variadic frobnicator
 

--- a/test/example-71-autofunction.rst
+++ b/test/example-71-autofunction.rst
@@ -1,5 +1,5 @@
 
-.. c:function:: int frob(struct list * list, enum mode mode)
+.. c:function:: int frob(struct list *list, enum mode mode)
 
    List frobnicator.
 

--- a/test/example-75-transform.rst
+++ b/test/example-75-transform.rst
@@ -1,5 +1,5 @@
 
-.. c:function:: int napoleon(int foo, char * bar)
+.. c:function:: int napoleon(int foo, char *bar)
 
    Custom comment transformations.
 

--- a/test/example-80-compat.rst
+++ b/test/example-80-compat.rst
@@ -1,5 +1,5 @@
 
-.. c:function:: int frob2(struct list * list, enum mode mode)
+.. c:function:: int frob2(struct list *list, enum mode mode)
 
    Compat comment transformations.
 

--- a/test/function.rst
+++ b/test/function.rst
@@ -26,12 +26,12 @@
    Clang removes spaces.
 
 
-.. c:function:: void function_pointer_param( void *(*hook)(void *, int))
+.. c:function:: void function_pointer_param(void *(*hook)(void *, int))
 
    Function pointer parameter.
 
 
-.. c:function:: void array_of_pointer_params(char * p[])
+.. c:function:: void array_of_pointer_params(char *p[])
 
    Array of pointers parameter.
 

--- a/test/struct.rst
+++ b/test/struct.rst
@@ -16,17 +16,17 @@
       array member
 
 
-   .. c:member:: void * pointer_member
+   .. c:member:: void *pointer_member
 
       pointer member
 
 
-   .. c:member::  int (*function_pointer_member)(int, int)
+   .. c:member:: int (*function_pointer_member)(int, int)
 
       function pointer member
 
 
-   .. c:member:: struct sample_struct * next
+   .. c:member:: struct sample_struct *next
 
       foo next
 

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -4,27 +4,27 @@
    This is a variable document.
 
 
-.. c:var::  int (*function_pointer_variable)(int *)
+.. c:var:: int (*function_pointer_variable)(int *)
 
    function pointer variable
 
 
-.. c:var::  int (**pointer_to_function_pointer_variable)(int)
+.. c:var:: int (**pointer_to_function_pointer_variable)(int)
 
    pointer to function pointer variable
 
 
-.. c:var::  void (*function_pointer_array[5])(void)
+.. c:var:: void (*function_pointer_array[5])(void)
 
    array of function pointers
 
 
-.. c:var::  const char *(*const function_pointer_with_qualifier)(const char *)
+.. c:var:: const char *(*const function_pointer_with_qualifier)(const char *)
 
    function pointer with lots of const qualifiers
 
 
-.. c:var:: char * array_of_pointers[1]
+.. c:var:: char *array_of_pointers[1]
 
    Array of pointers.
 


### PR DESCRIPTION
Looking over Robin's #86 I had a few ideas and started poking around only to notice that the parser and docstring modules still had a few blurry lines in their boundaries. This is a quick attempt at fixing those issues so that the parser has 0 effect in the output formatting. It also makes the formatting a bit more consistent overall.

This will conflict with #86 though it's not a big issue and I have local patches for it already if it matters.