### PR TITLE
Param names wip

### DIFF
--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -172,7 +172,8 @@ def _decl_fixup(cursor):
         for c in cursor.get_children():
             if c.kind == CursorKind.PARM_DECL:
                 arg_ttype, arg_name = _decl_fixup(c)
-                args.append(f'{arg_ttype}')
+                spacer = '' if not arg_name or arg_ttype.endswith('*') else ' '
+                args.append(f'{arg_ttype}{spacer}{arg_name}' if arg_name else arg_ttype)
         if cursor_type.is_function_variadic():
             args.append('...')
         if not args:

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -167,7 +167,10 @@ def _function_pointer_fixup(ttype, name):
 
     return ttype, name
 
-def _decl_fixup(ttype, name):
+def _decl_fixup(cursor):
+    ttype = cursor.type.spelling
+    name = cursor.spelling
+
     ttype, name = _array_fixup(ttype, name)
 
     ttype, name = _function_pointer_fixup(ttype, name)
@@ -210,7 +213,7 @@ def _recursive_parse(comments, cursor, nest):
 
     elif cursor.kind in [CursorKind.VAR_DECL, CursorKind.FIELD_DECL]:
         # Note: Preserve original name
-        ttype, decl_name = _decl_fixup(ttype, name)
+        ttype, decl_name = _decl_fixup(cursor)
 
         if cursor.kind == CursorKind.VAR_DECL:
             ds = docstring.VarDocstring(text=text, nest=nest, name=name,
@@ -274,7 +277,7 @@ def _recursive_parse(comments, cursor, nest):
         if cursor.type.kind == TypeKind.FUNCTIONPROTO:
             for c in cursor.get_children():
                 if c.kind == CursorKind.PARM_DECL:
-                    arg_ttype, arg_name = _decl_fixup(c.type.spelling, c.spelling)
+                    arg_ttype, arg_name = _decl_fixup(c)
                     args.extend([(arg_ttype, arg_name)])
 
             if cursor.type.is_function_variadic():

--- a/test/autostruct.rst
+++ b/test/autostruct.rst
@@ -11,8 +11,14 @@
       array member
 
 
-   .. c:member::  int (*function_pointer_member)(int, int)
+   .. c:member:: int (*function_pointer_member)(int, int)
 
-      function pointer member
+      function pointer member with parameter names omitted
 
 
+   .. c:member:: int (*other_function_pointer_member)(int foo, int bar)
+
+      function pointer member with parameter names
+
+      :param foo: the foo
+      :param bar: the bar

--- a/test/autostruct.yaml
+++ b/test/autostruct.yaml
@@ -6,3 +6,4 @@ directive-options:
   members:
   - array_member
   - function_pointer_member
+  - other_function_pointer_member

--- a/test/function.rst
+++ b/test/function.rst
@@ -26,7 +26,7 @@
    Clang removes spaces.
 
 
-.. c:function:: void function_pointer_param(void *(*hook)(void *, int))
+.. c:function:: void function_pointer_param(void *(*hook)(void *p, int n))
 
    Function pointer parameter.
 

--- a/test/struct.c
+++ b/test/struct.c
@@ -17,9 +17,16 @@ struct sample_struct {
 	 */
 	void *pointer_member;
 	/**
-	 * function pointer member
+	 * function pointer member with parameter names omitted
 	 */
 	int (*function_pointer_member)(int, int);
+	/**
+	 * function pointer member with parameter names
+	 *
+	 * :param foo: the foo
+	 * :param bar: the bar
+	 */
+	int (*other_function_pointer_member)(int foo, int bar);
 	/**
 	 * foo next
 	 */

--- a/test/struct.rst
+++ b/test/struct.rst
@@ -23,7 +23,15 @@
 
    .. c:member:: int (*function_pointer_member)(int, int)
 
-      function pointer member
+      function pointer member with parameter names omitted
+
+
+   .. c:member:: int (*other_function_pointer_member)(int foo, int bar)
+
+      function pointer member with parameter names
+
+      :param foo: the foo
+      :param bar: the bar
 
 
    .. c:member:: struct sample_struct *next
@@ -31,7 +39,7 @@
       foo next
 
 
-.. c:struct:: @anonymous_d395b02a54adefb5d094bf6d634d74d3
+.. c:struct:: @anonymous_7bf120438d254a91e1275b973de6a0eb
 
    Anonymous struct documentation.
 
@@ -46,7 +54,7 @@
    Named struct.
 
 
-   .. c:struct:: @anonymous_599b2b407b243a27c07e8bc5e7cd89a6
+   .. c:struct:: @anonymous_a63d10331be1a527625db63b8ace540f
 
       Anonymous sub-struct.
 
@@ -56,7 +64,7 @@
          Member foo.
 
 
-   .. c:union:: @anonymous_1e23b78307a72d6379776de1c90679d6
+   .. c:union:: @anonymous_69382278a84175c1cbff40d522114b38
 
       Anonymous sub-union.
 

--- a/test/variable.c
+++ b/test/variable.c
@@ -27,3 +27,8 @@ const char* (*const function_pointer_with_qualifier)(const char *in);
  * Array of pointers.
  */
 char *array_of_pointers[1];
+
+/**
+ * Multi-dimensional array.
+ */
+int multi_dim[1][2];

--- a/test/variable.c
+++ b/test/variable.c
@@ -9,6 +9,11 @@ static int sheesh;
 int (*function_pointer_variable)(int *param_name_ignored);
 
 /**
+ * variadic function pointer variable
+ */
+int (*variadic_function_pointer_variable)(int *param_name_ignored, ...);
+
+/**
  * pointer to function pointer variable
  */
 int (**pointer_to_function_pointer_variable)(int);
@@ -19,9 +24,29 @@ int (**pointer_to_function_pointer_variable)(int);
 void (*function_pointer_array[5])(void);
 
 /**
+ * array of array of function pointers
+ */
+void (*array_of_function_pointer_array[5][15])(void);
+
+/**
  * function pointer with lots of const qualifiers
  */
 const char* (*const function_pointer_with_qualifier)(const char *in);
+
+/**
+ * function pointer with multiple qualifiers
+ */
+const char* (*const volatile function_pointer_with_multiple_qualifiers)(const char *in);
+
+/**
+ * a complex type involving function pointers somehow
+ */
+const char* (*const *volatile *restrict legal_type_involving_function_pointer[12][3])(const char *in);
+
+/**
+ * function pointer to a function taking a function pointer as arg
+ */
+int (*function_pointer_with_function_pointer_arg)(float (*arg1)(char c));
 
 /**
  * Array of pointers.

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -28,3 +28,8 @@
 
    Array of pointers.
 
+
+.. c:var:: int multi_dim[1][2]
+
+   Multi-dimensional array.
+

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -4,7 +4,7 @@
    This is a variable document.
 
 
-.. c:var:: int (*function_pointer_variable)(int *)
+.. c:var:: int (*function_pointer_variable)(int *param_name_ignored)
 
    function pointer variable
 
@@ -19,7 +19,7 @@
    array of function pointers
 
 
-.. c:var:: const char *(*const function_pointer_with_qualifier)(const char *)
+.. c:var:: const char *(*const function_pointer_with_qualifier)(const char *in)
 
    function pointer with lots of const qualifiers
 

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -9,6 +9,11 @@
    function pointer variable
 
 
+.. c:var:: int (*variadic_function_pointer_variable)(int *param_name_ignored, ...)
+
+   variadic function pointer variable
+
+
 .. c:var:: int (**pointer_to_function_pointer_variable)(int)
 
    pointer to function pointer variable
@@ -19,9 +24,29 @@
    array of function pointers
 
 
+.. c:var:: void (*array_of_function_pointer_array[5][15])(void)
+
+   array of array of function pointers
+
+
 .. c:var:: const char *(*const function_pointer_with_qualifier)(const char *in)
 
    function pointer with lots of const qualifiers
+
+
+.. c:var:: const char *(*const volatile function_pointer_with_multiple_qualifiers)(const char *in)
+
+   function pointer with multiple qualifiers
+
+
+.. c:var:: const char *(*const*volatile*restrict legal_type_involving_function_pointer[12][3])(const char *in)
+
+   a complex type involving function pointers somehow
+
+
+.. c:var:: int (*function_pointer_with_function_pointer_arg)( float (*arg1)(char c))
+
+   function pointer to a function taking a function pointer as arg
 
 
 .. c:var:: char *array_of_pointers[1]


### PR DESCRIPTION
Building on the foundations laid by @robinbourianes-kalisio in #86. Throw the array regexp decl fixup to the curb as well, and do everything using clang. Still a wip, the whitepace handling is ugly to say the least.
