### PR TITLE
Diagnostics v2

### DIFF
--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -39,21 +39,18 @@ class CAutoBaseDirective(SphinxDirective):
     _docstring_types = None
 
     def __display_parser_diagnostics(self, errors):
-        # Map parser diagnostic level to Sphinx verbosity and level name
+        # Map parser diagnostic level to Sphinx level name
         log_level_map = {
-            logging.DEBUG: (3, 'DEBUG'),
-            logging.INFO: (3, 'INFO'),
-            logging.WARNING: (1, 'WARNING'),
-            logging.ERROR: (0, 'ERROR'),
-            logging.CRITICAL: (0, 'CRITICAL'),
+            logging.DEBUG: 'DEBUG',
+            logging.INFO: 'VERBOSE',
+            logging.WARNING: 'WARNING',
+            logging.ERROR: 'ERROR',
+            logging.CRITICAL: 'CRITICAL',
         }
 
         for error in errors:
-            verbosity, level = log_level_map[error.level]
-
-            if verbosity <= self.env.app.verbosity:
-                self.logger.log(level, error.get_message(),
-                                location=(self.env.docname, self.lineno))
+            self.logger.log(log_level_map[error.level], error.get_message(),
+                            location=(self.env.docname, self.lineno))
 
     def __get_clang_args(self):
         clang_args = self.env.config.cautodoc_clang.copy()

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -44,14 +44,9 @@ class CAutoBaseDirective(SphinxDirective):
                 ErrorLevel.DEBUG: logging.LEVEL_NAMES['DEBUG']}
 
     def __display_parser_diagnostics(self, errors):
-        for (severity, filename, lineno, msg) in errors:
-            if filename:
-                toprint = f'{filename}:{lineno}: {msg}'
-            else:
-                toprint = f'{msg}'
-
-            if severity.value <= self.env.app.verbosity:
-                self.logger.log(self._log_lvl[severity], toprint,
+        for error in errors:
+            if error.level.value <= self.env.app.verbosity:
+                self.logger.log(self._log_lvl[error.level], error.get_message(),
                                 location=(self.env.docname, self.lineno))
 
     def __get_clang_args(self):

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -42,7 +42,7 @@ def main():
         print(comment.get_docstring(transform=transform))
 
     for error in errors:
-        print(f'{error.level.name}: {error.get_message()}', file=sys.stderr)
+        print(f'{error.get_level_name()}: {error.get_message()}', file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -41,12 +41,8 @@ def main():
             print(f'# {comment.get_meta()}')
         print(comment.get_docstring(transform=transform))
 
-    for (severity, filename, lineno, msg) in errors:
-        if filename:
-            print(f'{severity.name}: {filename}:{lineno}: {msg}',
-                  file=sys.stderr)
-        else:
-            print(f'{severity.name}: {msg}', file=sys.stderr)
+    for error in errors:
+        print(f'{error.level.name}: {error.get_message()}', file=sys.stderr)
 
 if __name__ == '__main__':
     main()

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -32,6 +32,7 @@ The documentation comments are returned verbatim in a tree of Docstring objects.
 
 import enum
 import re
+from dataclasses import dataclass
 
 from clang.cindex import TokenKind, CursorKind, TypeKind
 from clang.cindex import Index, TranslationUnit
@@ -47,6 +48,19 @@ class ErrorLevel(enum.Enum):
     WARNING = 1
     INFO = 2
     DEBUG = 3
+
+@dataclass
+class ParserError:
+    level: ErrorLevel
+    filename: str
+    line: int
+    message: str
+
+    def get_message(self):
+        if self.filename:
+            return f'{self.filename}:{self.line}: {self.message}'
+        else:
+            return f'{self.message}'
 
 def _comment_extract(tu):
 
@@ -333,8 +347,8 @@ def _clang_diagnostics(diagnostics):
 
     for diag in diagnostics:
         filename = diag.location.file.name if diag.location.file else None
-        errors.extend([(sev[diag.severity], filename,
-                        diag.location.line, diag.spelling)])
+        errors.append(ParserError(sev[diag.severity], filename,
+                                  diag.location.line, diag.spelling))
 
     return errors
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -38,8 +38,8 @@ def _get_output(testcase, **options):
     for comment in comments.walk():
         docs_str += comment.get_docstring(transform=transform) + '\n'
 
-    for (severity, filename, lineno, msg) in errors:
-        errors_str += f'{severity.name}: {os.path.basename(filename)}:{lineno}: {msg}\n'
+    for error in errors:
+        errors_str += f'{error.level.name}: {os.path.basename(error.filename)}:{error.line}: {error.message}\n'  # noqa: E501
 
     return docs_str, errors_str
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -39,7 +39,7 @@ def _get_output(testcase, **options):
         docs_str += comment.get_docstring(transform=transform) + '\n'
 
     for error in errors:
-        errors_str += f'{error.level.name}: {os.path.basename(error.filename)}:{error.line}: {error.message}\n'  # noqa: E501
+        errors_str += f'{error.get_level_name()}: {os.path.basename(error.filename)}:{error.line}: {error.message}\n'  # noqa: E501
 
     return docs_str, errors_str
 


### PR DESCRIPTION
This superseeds #97.

I've switched the order of commits 2 and 3, and addressed the review concerns.

Additionally, new commit 4 drops the verbosity filtering/mapping, and lets Sphinx do that part. This makes parts of commit 3 temporary in the interest of not making functional changes in that.
