### PR TITLE
test: add a separate test for clang diagnostics

### DIFF
--- a/test/clang-diagnostics.c
+++ b/test/clang-diagnostics.c
@@ -1,0 +1,4 @@
+/**
+ * struct list and enum mode aren't declared.
+ */
+int frob(struct list *list, enum mode mode);

--- a/test/clang-diagnostics.rst
+++ b/test/clang-diagnostics.rst
@@ -1,0 +1,5 @@
+
+.. c:function:: int frob(struct list *list, enum mode mode)
+
+   struct list and enum mode aren't declared.
+

--- a/test/clang-diagnostics.stderr
+++ b/test/clang-diagnostics.stderr
@@ -1,0 +1,2 @@
+WARNING: clang-diagnostics.c:4: declaration of 'struct list' will not be visible outside of this function
+WARNING: clang-diagnostics.c:4: declaration of 'enum mode' will not be visible outside of this function

--- a/test/clang-diagnostics.yaml
+++ b/test/clang-diagnostics.yaml
@@ -1,0 +1,2 @@
+directive-arguments:
+- clang-diagnostics.c

--- a/test/example-compat.c
+++ b/test/example-compat.c
@@ -1,3 +1,6 @@
+struct list;
+enum mode;
+
 /**
  * Compat comment transformations.
  *

--- a/test/example-compat.stderr
+++ b/test/example-compat.stderr
@@ -1,2 +1,0 @@
-WARNING: example-compat.c:13: declaration of 'struct list' will not be visible outside of this function
-WARNING: example-compat.c:13: declaration of 'enum mode' will not be visible outside of this function

--- a/test/example-function.c
+++ b/test/example-function.c
@@ -1,3 +1,6 @@
+struct list;
+enum mode;
+
 /**
  * List frobnicator.
  *

--- a/test/example-function.stderr
+++ b/test/example-function.stderr
@@ -1,2 +1,0 @@
-WARNING: example-function.c:9: declaration of 'struct list' will not be visible outside of this function
-WARNING: example-function.c:9: declaration of 'enum mode' will not be visible outside of this function


### PR DESCRIPTION
The examples contain build warnings that now show up in 'make html' by default:

doc/examples.rst:174: WARNING: test/example-function.c:9: declaration of 'struct list' will not be visible outside of this function doc/examples.rst:174: WARNING: test/example-function.c:9: declaration of 'enum mode' will not be visible outside of this function doc/examples.rst:365: WARNING: test/example-compat.c:13: declaration of 'struct list' will not be visible outside of this function doc/examples.rst:365: WARNING: test/example-compat.c:13: declaration of 'enum mode' will not be visible outside of this function

Add a separate test for clang diagnostics, with build warnings, and fix the warnings in the examples to have a clean 'make html'.