### PR TITLE
Random clean ups

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,7 +60,7 @@ try:
         config = Config(napoleon_use_rtype=False)
         return str(docstring.GoogleDocstring(comment, config))
 
-    cautodoc_transformations = {
+    hawkmoth_transformations = {
         'napoleon': napoleon_transform,
         'javadoc-liberal': doccompat.javadoc_liberal,
     }
@@ -71,7 +71,7 @@ except ImportError:
     # into the documentation instead of generating.
     extensions.append('automock')
 
-cautodoc_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../test')
+hawkmoth_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../test')
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -25,7 +25,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
-class CAutoBaseDirective(SphinxDirective):
+class _AutoBaseDirective(SphinxDirective):
     logger = logging.getLogger(__name__)
 
     option_spec = {
@@ -153,7 +153,7 @@ class CAutoBaseDirective(SphinxDirective):
 
         return node.children
 
-class CAutoDocDirective(CAutoBaseDirective):
+class _AutoDocDirective(_AutoBaseDirective):
     """Extract all documentation comments from the specified files"""
 
     # Allow passing a variable number of file patterns as arguments
@@ -176,13 +176,13 @@ class CAutoDocDirective(CAutoBaseDirective):
                                         location=(self.env.docname, self.lineno))
 
 # Base class for named stuff
-class CAutoSymbolDirective(CAutoBaseDirective):
+class _AutoSymbolDirective(_AutoBaseDirective):
     """Extract specified documentation comments from the specified file"""
 
     required_arguments = 1
     optional_arguments = 0
 
-    option_spec = CAutoBaseDirective.option_spec.copy()
+    option_spec = _AutoBaseDirective.option_spec.copy()
     option_spec.update({
         'file': directives.unchanged_required,
     })
@@ -201,41 +201,44 @@ class CAutoSymbolDirective(CAutoBaseDirective):
     def _get_names(self):
         return [self.arguments[0]]
 
-class CAutoVarDirective(CAutoSymbolDirective):
-    _docstring_types = [docstring.VarDocstring]
-
-class CAutoTypeDirective(CAutoSymbolDirective):
-    _docstring_types = [docstring.TypeDocstring]
-
-class CAutoMacroDirective(CAutoSymbolDirective):
-    _docstring_types = [docstring.MacroDocstring, docstring.MacroFunctionDocstring]
-
-class CAutoFunctionDirective(CAutoSymbolDirective):
-    _docstring_types = [docstring.FunctionDocstring]
-
-def members_filter(argument):
+def _members_filter(argument):
     # Use None for members option without an argument to not filter.
     if argument is None:
         return None
     return strutil.string_list(argument)
 
-class CAutoCompoundDirective(CAutoSymbolDirective):
-    option_spec = CAutoSymbolDirective.option_spec.copy()
+class _AutoCompoundDirective(_AutoSymbolDirective):
+    option_spec = _AutoSymbolDirective.option_spec.copy()
     option_spec.update({
-        'members': members_filter,
+        'members': _members_filter,
     })
 
     def _get_members(self):
         # By default use [] as a filter that does not match any members.
         return self.options.get('members', [])
 
-class CAutoStructDirective(CAutoCompoundDirective):
+class CAutoDocDirective(_AutoDocDirective):
+    pass
+
+class CAutoVarDirective(_AutoSymbolDirective):
+    _docstring_types = [docstring.VarDocstring]
+
+class CAutoTypeDirective(_AutoSymbolDirective):
+    _docstring_types = [docstring.TypeDocstring]
+
+class CAutoMacroDirective(_AutoSymbolDirective):
+    _docstring_types = [docstring.MacroDocstring, docstring.MacroFunctionDocstring]
+
+class CAutoFunctionDirective(_AutoSymbolDirective):
+    _docstring_types = [docstring.FunctionDocstring]
+
+class CAutoStructDirective(_AutoCompoundDirective):
     _docstring_types = [docstring.StructDocstring]
 
-class CAutoUnionDirective(CAutoCompoundDirective):
+class CAutoUnionDirective(_AutoCompoundDirective):
     _docstring_types = [docstring.UnionDocstring]
 
-class CAutoEnumDirective(CAutoCompoundDirective):
+class CAutoEnumDirective(_AutoCompoundDirective):
     _docstring_types = [docstring.EnumDocstring]
 
 def setup(app):

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -8,17 +8,23 @@ python3 -m hawkmoth
 """
 
 import argparse
+import os
 import sys
 
 from hawkmoth.parser import parse
 from hawkmoth.util import doccompat
+
+def filename(file):
+    if os.path.isfile(file):
+        return file
+    raise ValueError
 
 def main():
     parser = argparse.ArgumentParser(prog='hawkmoth', description="""
     Hawkmoth parser debug tool. Print the documentation comments extracted
     from FILE, along with the generated C Domain directives, to standard
     output. Include metadata with verbose output.""")
-    parser.add_argument('file', metavar='FILE', type=str, action='store',
+    parser.add_argument('file', metavar='FILE', type=filename, action='store',
                         help='The C source or header file to parse.')
     parser.add_argument('--compat',
                         choices=['none',

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -188,15 +188,15 @@ class TypeDocstring(Docstring):
 
 class _CompoundDocstring(Docstring):
     def _get_decl_name(self):
-        # The empty string for decl_name means anonymous.
-        if self._decl_name == '':
+        # If decl_name is empty, it means this is an anonymous declaration.
+        if self._decl_name is None:
             # Sphinx expects @name for anonymous entities. The name must be both
             # stable and unique. Create one.
             decl_name = hashlib.md5(f'{self._text}{self.get_line()}'.encode()).hexdigest()
 
             return f'@anonymous_{decl_name}'
 
-        return super()._get_decl_name()
+        return self._decl_name
 
 class StructDocstring(_CompoundDocstring):
     _indent = 1

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -332,25 +332,22 @@ def _recursive_parse(comments, errors, cursor, nest):
 
     return [ds]
 
-def _clang_diagnostics(diagnostics):
-    errors = []
-
+def _clang_diagnostics(diagnostics, errors):
     for diag in diagnostics:
         filename = diag.location.file.name if diag.location.file else None
         errors.append(ParserError(ErrorLevel(diag.severity), filename,
                                   diag.location.line, diag.spelling))
 
-    return errors
-
 # Parse a file and return a tree of docstring.Docstring objects.
 def parse(filename, clang_args=None):
+    errors = []
     index = Index.create()
 
     tu = index.parse(filename, args=clang_args,
                      options=TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD |
                      TranslationUnit.PARSE_SKIP_FUNCTION_BODIES)
 
-    errors = _clang_diagnostics(tu.diagnostics)
+    _clang_diagnostics(tu.diagnostics, errors)
 
     top_level_comments, comments = _comment_extract(tu)
 

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-2017 Jani Nikula <jani@nikula.org>
-# Copyright (c) 2018-2022 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
+# Copyright (c) 2018-2023 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 """
 Documentation comment extractor
@@ -73,12 +73,12 @@ def _comment_extract(tu):
 
     top_level_comments = []
     comments = {}
-    cursor = None
     current_comment = None
+
     for token in tu.get_tokens(extent=tu.cursor.extent):
-        # handle all comments we come across
+        # Handle all comments we come across.
         if token.kind == TokenKind.COMMENT:
-            # if we already have a comment, it wasn't related to a cursor
+            # If we already have a comment, it wasn't related to another cursor.
             if current_comment and docstring.Docstring.is_doc(current_comment.spelling):
                 top_level_comments.append(current_comment)
             current_comment = token
@@ -88,25 +88,21 @@ def _comment_extract(tu):
         # instead of accessing the `cursor` property multiple times.
         token_cursor = token.cursor
 
-        # cursors that are 1) never documented themselves, and 2) allowed
-        # between comment and the actual cursor being documented
+        # Cursors that are 1) never documented themselves, and 2) allowed
+        # between the comment and the actual cursor being documented.
         if token_cursor.kind in [CursorKind.INVALID_FILE,
                                  CursorKind.TYPE_REF,
                                  CursorKind.PREPROCESSING_DIRECTIVE,
                                  CursorKind.MACRO_INSTANTIATION]:
             continue
 
-        if cursor is not None and token_cursor == cursor:
-            continue
-
-        cursor = token_cursor
-
-        # Note: current_comment may be None
-        if current_comment is not None and docstring.Docstring.is_doc(current_comment.spelling):
-            comments[cursor.hash] = current_comment
+        # Otherwise the current comment documents _this_ cursor. I.e.: not a top
+        # level comment.
+        if current_comment and docstring.Docstring.is_doc(current_comment.spelling):
+            comments[token_cursor.hash] = current_comment
         current_comment = None
 
-    # comment at the end of file
+    # Comment at the end of file.
     if current_comment and docstring.Docstring.is_doc(current_comment.spelling):
         top_level_comments.append(current_comment)
 

--- a/test/autoenum.yaml
+++ b/test/autoenum.yaml
@@ -1,8 +1,8 @@
 directive: autoenum
 directive-arguments:
-- foo
+  - foo
 directive-options:
   file: enum.c
   members:
-  - bar
+    - bar
 

--- a/test/autostruct-no-members.yaml
+++ b/test/autostruct-no-members.yaml
@@ -1,5 +1,5 @@
 directive: autostruct
 directive-arguments:
-- sample_struct
+  - sample_struct
 directive-options:
   file: struct.c

--- a/test/autostruct.yaml
+++ b/test/autostruct.yaml
@@ -1,9 +1,9 @@
 directive: autostruct
 directive-arguments:
-- sample_struct
+  - sample_struct
 directive-options:
   file: struct.c
   members:
-  - array_member
-  - function_pointer_member
-  - other_function_pointer_member
+    - array_member
+    - function_pointer_member
+    - other_function_pointer_member

--- a/test/autovariable-fnptr-array.yaml
+++ b/test/autovariable-fnptr-array.yaml
@@ -1,5 +1,5 @@
 directive: autovar
 directive-arguments:
-- function_pointer_array
+  - function_pointer_array
 directive-options:
   file: variable.c

--- a/test/clang-diagnostics.yaml
+++ b/test/clang-diagnostics.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- clang-diagnostics.c
+  - clang-diagnostics.c

--- a/test/comment-strip.yaml
+++ b/test/comment-strip.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- comment-strip.c
+  - comment-strip.c

--- a/test/compat-javadoc-basic.yaml
+++ b/test/compat-javadoc-basic.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- compat.c
+  - compat.c
 directive-options:
   compat: javadoc-basic

--- a/test/compat-javadoc-liberal.yaml
+++ b/test/compat-javadoc-liberal.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- compat.c
+  - compat.c
 directive-options:
   compat: javadoc-liberal

--- a/test/compat-kernel-doc.yaml
+++ b/test/compat-kernel-doc.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- compat.c
+  - compat.c
 directive-options:
   compat: kernel-doc

--- a/test/compat.yaml
+++ b/test/compat.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- compat.c
+  - compat.c

--- a/test/composition.yaml
+++ b/test/composition.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- composition.c
+  - composition.c

--- a/test/doc.yaml
+++ b/test/doc.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- doc.c
+  - doc.c

--- a/test/enum.yaml
+++ b/test/enum.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- enum.c
+  - enum.c

--- a/test/example-autodoc.yaml
+++ b/test/example-autodoc.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-autodoc.c
+  - example-autodoc.c
 example-title: Overview
 example-priority: 1

--- a/test/example-autofunction.yaml
+++ b/test/example-autofunction.yaml
@@ -1,6 +1,6 @@
 directive: autofunction
 directive-arguments:
-- frob
+  - frob
 directive-options:
   file: example-function.c
 example-use-namespace: yes

--- a/test/example-automacro.yaml
+++ b/test/example-automacro.yaml
@@ -1,6 +1,6 @@
 directive: automacro
 directive-arguments:
-- DIE
+  - DIE
 directive-options:
   file: example-macro.c
 example-use-namespace: yes

--- a/test/example-autostruct.yaml
+++ b/test/example-autostruct.yaml
@@ -1,6 +1,6 @@
 directive: autostruct
 directive-arguments:
-- list
+  - list
 directive-options:
   file: example-struct.c
   members:

--- a/test/example-autounion.yaml
+++ b/test/example-autounion.yaml
@@ -1,6 +1,6 @@
 directive: autounion
 directive-arguments:
-- onion
+  - onion
 directive-options:
   file: example-autounion.c
   members:

--- a/test/example-autovar.yaml
+++ b/test/example-autovar.yaml
@@ -1,6 +1,6 @@
 directive: autovar
 directive-arguments:
-- meaning_of_life
+  - meaning_of_life
 directive-options:
   file: example-variable.c
 example-use-namespace: yes

--- a/test/example-compat.yaml
+++ b/test/example-compat.yaml
@@ -1,5 +1,5 @@
 directive-arguments:
-- example-compat.c
+  - example-compat.c
 directive-options:
   transform: javadoc-liberal
 example-title: Compat

--- a/test/example-enum.yaml
+++ b/test/example-enum.yaml
@@ -1,6 +1,6 @@
 directive: autoenum
 directive-arguments:
-- mode
+  - mode
 directive-options:
   file: example-enum.c
   members:

--- a/test/example-function.yaml
+++ b/test/example-function.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-function.c
+  - example-function.c
 example-title: Function
 example-priority: 40

--- a/test/example-macro.yaml
+++ b/test/example-macro.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-macro.c
+  - example-macro.c
 example-title: Macro
 example-priority: 30

--- a/test/example-preprocessor.yaml
+++ b/test/example-preprocessor.yaml
@@ -1,7 +1,7 @@
 directive-arguments:
-- example-preprocessor.c
+  - example-preprocessor.c
 directive-options:
   clang:
-  - -DDEEP_THOUGHT
+    - -DDEEP_THOUGHT
 example-title: Preprocessor
 example-priority: 80

--- a/test/example-struct.yaml
+++ b/test/example-struct.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-struct.c
+  - example-struct.c
 example-title: Struct
 example-priority: 50

--- a/test/example-transform.yaml
+++ b/test/example-transform.yaml
@@ -1,5 +1,5 @@
 directive-arguments:
-- example-transform.c
+  - example-transform.c
 directive-options:
   transform: napoleon
 example-title: Transform

--- a/test/example-typedef.yaml
+++ b/test/example-typedef.yaml
@@ -1,6 +1,6 @@
 directive: autotype
 directive-arguments:
-- list_data_t
+  - list_data_t
 directive-options:
   file: example-typedef.c
 example-title: Typedef

--- a/test/example-variable.yaml
+++ b/test/example-variable.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-variable.c
+  - example-variable.c
 example-title: Variable
 example-priority: 10

--- a/test/function-like-macro.yaml
+++ b/test/function-like-macro.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- function-like-macro.c
+  - function-like-macro.c

--- a/test/function.yaml
+++ b/test/function.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- function.c
+  - function.c

--- a/test/meta-expected-failure.yaml
+++ b/test/meta-expected-failure.yaml
@@ -1,3 +1,3 @@
 directive-arguments:
-- meta-expected-failure.c
+  - meta-expected-failure.c
 expected-failure: true

--- a/test/simple-macro.yaml
+++ b/test/simple-macro.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- simple-macro.c
+  - simple-macro.c

--- a/test/struct.yaml
+++ b/test/struct.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- struct.c
+  - struct.c

--- a/test/typedef-enum.rst
+++ b/test/typedef-enum.rst
@@ -9,7 +9,7 @@
       named enumeration
 
 
-.. c:enum:: unnamed_t
+.. c:enum:: @anonymous_90372874a3c8c25dccf983612f39e93f
 
    unnamed typedeffed enum
 

--- a/test/typedef-enum.yaml
+++ b/test/typedef-enum.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- typedef-enum.c
+  - typedef-enum.c

--- a/test/typedef-struct.rst
+++ b/test/typedef-struct.rst
@@ -9,7 +9,7 @@
       named member
 
 
-.. c:struct:: typedef_struct
+.. c:struct:: @anonymous_7f9a1d628cd33f3227f3fcdc3a405aa6
 
    unnamed typedeffed struct
 

--- a/test/typedef-struct.yaml
+++ b/test/typedef-struct.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- typedef-struct.c
+  - typedef-struct.c

--- a/test/typedef.yaml
+++ b/test/typedef.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- typedef.c
+  - typedef.c

--- a/test/union.yaml
+++ b/test/union.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- union.c
+  - union.c

--- a/test/variable.yaml
+++ b/test/variable.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- variable.c
+  - variable.c


### PR DESCRIPTION
Collection of changes I stumbled on while working on C++ support that are not (strictly) related to C++ and thus can be merged ahead.

I think the only contentious / tricky one is the parser fix 241cda39432a67529d72f2be6edc2fa63523449f. In the past I remember wanting the original behaviour somehow, but as I explain in that commit, I don't think we should do it, or at least not without a much larger effort to make sure we have consistent behaviour across the board.

Note this commit, if accepted, will replace the commit 49827c2ae5c0e4258e20beab1635e46290156020 in the C++ branch entirely.