### PR TITLE
Random clean-ups v2

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -71,7 +71,7 @@ except ImportError:
     # into the documentation instead of generating.
     extensions.append('automock')
 
-cautodoc_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../test')
+hawkmoth_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../test')
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -33,7 +33,7 @@ Configuration
 
 The extension has a few configuration options that can be set in ``conf.py``:
 
-.. py:data:: cautodoc_root
+.. py:data:: hawkmoth_root
    :type: str
 
    Path to the root of the source files. Defaults to the
@@ -46,7 +46,7 @@ The extension has a few configuration options that can be set in ``conf.py``:
    .. code-block:: python
 
       import os
-      cautodoc_root = os.path.abspath('my/sources/dir')
+      hawkmoth_root = os.path.abspath('my/sources/dir')
 
 .. py:data:: cautodoc_transformations
    :type: dict
@@ -88,7 +88,7 @@ The extension has a few configuration options that can be set in ``conf.py``:
           'kernel-doc': doccompat.kerneldoc,
       }
 
-.. py:data:: cautodoc_clang
+.. py:data:: hawkmoth_clang
    :type: list
 
    A list of arguments to pass to ``clang`` while parsing the source, typically
@@ -99,7 +99,7 @@ The extension has a few configuration options that can be set in ``conf.py``:
 
    .. code-block:: python
 
-      cautodoc_clang = ['-I/path/to/include', '-DHAWKMOTH']
+      hawkmoth_clang = ['-I/path/to/include', '-DHAWKMOTH']
 
    Hawkmoth provides a convenience helper for querying the include path from the
    compiler, and providing them as ``-I`` options:
@@ -108,7 +108,28 @@ The extension has a few configuration options that can be set in ``conf.py``:
 
       from hawkmoth.util import compiler
 
-      cautodoc_clang = compiler.get_include_args()
+      hawkmoth_clang = compiler.get_include_args()
 
    You can also pass in the compiler to use, for example
    ``get_include_args('gcc')``.
+
+.. py:data:: cautodoc_root
+   :type: str
+
+   Equivalent to :py:data:`hawkmoth_root`.
+
+   .. warning::
+
+      The ``cautodoc_root`` option has been deprecated in favour of the
+      :py:data:`hawkmoth_root` option and will be removed in the future.
+
+.. py:data:: cautodoc_clang
+   :type: str
+
+   Equivalent to :py:data:`hawkmoth_clang`.
+
+   .. warning::
+
+      The ``cautodoc_clang`` option has been deprecated in favour of
+      the :py:data:`hawkmoth_clang` option and will be removed in the
+      future.

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -198,15 +198,15 @@ class TypeDocstring(Docstring):
 
 class _CompoundDocstring(Docstring):
     def _get_decl_name(self):
-        # The empty string for decl_name means anonymous.
-        if self._decl_name == '':
+        # If decl_name is empty, it means this is an anonymous declaration.
+        if self._decl_name is None:
             # Sphinx expects @name for anonymous entities. The name must be both
             # stable and unique. Create one.
             decl_name = hashlib.md5(f'{self._text}{self.get_line()}'.encode()).hexdigest()
 
             return f'@anonymous_{decl_name}'
 
-        return super()._get_decl_name()
+        return self._decl_name
 
 class StructDocstring(_CompoundDocstring):
     _indent = 1

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -31,7 +31,6 @@ The documentation comments are returned verbatim in a tree of Docstring objects.
 """
 
 import enum
-import re
 from dataclasses import dataclass
 
 from clang.cindex import TokenKind, CursorKind, TypeKind
@@ -208,21 +207,6 @@ def _type_fixup(cursor):
 
     return ttype, name
 
-# name may be empty for typedefs and anonymous enums, structs and unions
-def _anonymous_fixup(ttype, name):
-    if name:
-        return ttype, name
-
-    mo = re.match(r'(?a)^(?P<type>enum|struct|union) ([^:]+::)?\((anonymous|unnamed) at [^)]+\)$', ttype)  # noqa: E501
-    if mo:
-        # Anonymous
-        name = ''
-    else:
-        # Typedef
-        name = ttype
-
-    return ttype, name
-
 def _get_args(cursor):
     """Get function / method arguments."""
     args = []
@@ -283,17 +267,8 @@ def _recursive_parse(comments, errors, cursor, nest):
     elif cursor.kind in [CursorKind.STRUCT_DECL, CursorKind.UNION_DECL,
                          CursorKind.ENUM_DECL]:
 
-        # FIXME:
-        # Handle cases where variables are instantiated on type declaration,
-        # including anonymous cases. Idea is that if there is a variable
-        # instantiation, the documentation should be applied to the variable if
-        # the structure is anonymous or to the type otherwise.
-        #
-        # Due to the new recursiveness of the parser, fixing this here, _should_
-        # handle all cases (struct, union, enum).
-
-        # Note: Preserve original name
-        ttype, decl_name = _anonymous_fixup(ttype, name)
+        # Do not set the decl_name for anonymous symbols (empty spelling).
+        decl_name = name if cursor.spelling != '' else None
 
         if cursor.kind == CursorKind.STRUCT_DECL:
             ds = docstring.StructDocstring(text=text, nest=nest, name=name,

--- a/test/autoenum.yaml
+++ b/test/autoenum.yaml
@@ -1,8 +1,8 @@
 directive: autoenum
 directive-arguments:
-- foo
+  - foo
 directive-options:
   file: enum.c
   members:
-  - bar
+    - bar
 

--- a/test/autostruct-no-members.yaml
+++ b/test/autostruct-no-members.yaml
@@ -1,5 +1,5 @@
 directive: autostruct
 directive-arguments:
-- sample_struct
+  - sample_struct
 directive-options:
   file: struct.c

--- a/test/autostruct.yaml
+++ b/test/autostruct.yaml
@@ -1,9 +1,9 @@
 directive: autostruct
 directive-arguments:
-- sample_struct
+  - sample_struct
 directive-options:
   file: struct.c
   members:
-  - array_member
-  - function_pointer_member
-  - other_function_pointer_member
+    - array_member
+    - function_pointer_member
+    - other_function_pointer_member

--- a/test/autovariable-fnptr-array.yaml
+++ b/test/autovariable-fnptr-array.yaml
@@ -1,5 +1,5 @@
 directive: autovar
 directive-arguments:
-- function_pointer_array
+  - function_pointer_array
 directive-options:
   file: variable.c

--- a/test/clang-diagnostics.yaml
+++ b/test/clang-diagnostics.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- clang-diagnostics.c
+  - clang-diagnostics.c

--- a/test/comment-strip.yaml
+++ b/test/comment-strip.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- comment-strip.c
+  - comment-strip.c

--- a/test/composition.yaml
+++ b/test/composition.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- composition.c
+  - composition.c

--- a/test/doc.yaml
+++ b/test/doc.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- doc.c
+  - doc.c

--- a/test/enum.yaml
+++ b/test/enum.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- enum.c
+  - enum.c

--- a/test/example-autodoc.yaml
+++ b/test/example-autodoc.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-autodoc.c
+  - example-autodoc.c
 example-title: Overview
 example-priority: 1

--- a/test/example-autofunction.yaml
+++ b/test/example-autofunction.yaml
@@ -1,6 +1,6 @@
 directive: autofunction
 directive-arguments:
-- frob
+  - frob
 directive-options:
   file: example-function.c
 example-use-namespace: yes

--- a/test/example-automacro.yaml
+++ b/test/example-automacro.yaml
@@ -1,6 +1,6 @@
 directive: automacro
 directive-arguments:
-- DIE
+  - DIE
 directive-options:
   file: example-macro.c
 example-use-namespace: yes

--- a/test/example-autostruct.yaml
+++ b/test/example-autostruct.yaml
@@ -1,6 +1,6 @@
 directive: autostruct
 directive-arguments:
-- list
+  - list
 directive-options:
   file: example-struct.c
   members:

--- a/test/example-autounion.yaml
+++ b/test/example-autounion.yaml
@@ -1,6 +1,6 @@
 directive: autounion
 directive-arguments:
-- onion
+  - onion
 directive-options:
   file: example-autounion.c
   members:

--- a/test/example-autovar.yaml
+++ b/test/example-autovar.yaml
@@ -1,6 +1,6 @@
 directive: autovar
 directive-arguments:
-- meaning_of_life
+  - meaning_of_life
 directive-options:
   file: example-variable.c
 example-use-namespace: yes

--- a/test/example-compat.yaml
+++ b/test/example-compat.yaml
@@ -1,5 +1,5 @@
 directive-arguments:
-- example-compat.c
+  - example-compat.c
 directive-options:
   transform: javadoc-liberal
 example-title: Compat

--- a/test/example-enum.yaml
+++ b/test/example-enum.yaml
@@ -1,6 +1,6 @@
 directive: autoenum
 directive-arguments:
-- mode
+  - mode
 directive-options:
   file: example-enum.c
   members:

--- a/test/example-function.yaml
+++ b/test/example-function.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-function.c
+  - example-function.c
 example-title: Function
 example-priority: 40

--- a/test/example-macro.yaml
+++ b/test/example-macro.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-macro.c
+  - example-macro.c
 example-title: Macro
 example-priority: 30

--- a/test/example-preprocessor.yaml
+++ b/test/example-preprocessor.yaml
@@ -1,7 +1,7 @@
 directive-arguments:
-- example-preprocessor.c
+  - example-preprocessor.c
 directive-options:
   clang:
-  - -DDEEP_THOUGHT
+    - -DDEEP_THOUGHT
 example-title: Preprocessor
 example-priority: 80

--- a/test/example-struct.yaml
+++ b/test/example-struct.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-struct.c
+  - example-struct.c
 example-title: Struct
 example-priority: 50

--- a/test/example-transform.yaml
+++ b/test/example-transform.yaml
@@ -1,5 +1,5 @@
 directive-arguments:
-- example-transform.c
+  - example-transform.c
 directive-options:
   transform: napoleon
 example-title: Transform

--- a/test/example-typedef.yaml
+++ b/test/example-typedef.yaml
@@ -1,6 +1,6 @@
 directive: autotype
 directive-arguments:
-- list_data_t
+  - list_data_t
 directive-options:
   file: example-typedef.c
 example-title: Typedef

--- a/test/example-variable.yaml
+++ b/test/example-variable.yaml
@@ -1,4 +1,4 @@
 directive-arguments:
-- example-variable.c
+  - example-variable.c
 example-title: Variable
 example-priority: 10

--- a/test/function-like-macro.yaml
+++ b/test/function-like-macro.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- function-like-macro.c
+  - function-like-macro.c

--- a/test/function.yaml
+++ b/test/function.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- function.c
+  - function.c

--- a/test/meta-expected-failure.yaml
+++ b/test/meta-expected-failure.yaml
@@ -1,3 +1,3 @@
 directive-arguments:
-- meta-expected-failure.c
+  - meta-expected-failure.c
 expected-failure: true

--- a/test/simple-macro.yaml
+++ b/test/simple-macro.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- simple-macro.c
+  - simple-macro.c

--- a/test/struct.yaml
+++ b/test/struct.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- struct.c
+  - struct.c

--- a/test/typedef-enum.rst
+++ b/test/typedef-enum.rst
@@ -9,7 +9,7 @@
       named enumeration
 
 
-.. c:enum:: unnamed_t
+.. c:enum:: @anonymous_90372874a3c8c25dccf983612f39e93f
 
    unnamed typedeffed enum
 

--- a/test/typedef-enum.yaml
+++ b/test/typedef-enum.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- typedef-enum.c
+  - typedef-enum.c

--- a/test/typedef-struct.rst
+++ b/test/typedef-struct.rst
@@ -9,7 +9,7 @@
       named member
 
 
-.. c:struct:: typedef_struct
+.. c:struct:: @anonymous_7f9a1d628cd33f3227f3fcdc3a405aa6
 
    unnamed typedeffed struct
 

--- a/test/typedef-struct.yaml
+++ b/test/typedef-struct.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- typedef-struct.c
+  - typedef-struct.c

--- a/test/typedef.yaml
+++ b/test/typedef.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- typedef.c
+  - typedef.c

--- a/test/union.yaml
+++ b/test/union.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- union.c
+  - union.c

--- a/test/variable.yaml
+++ b/test/variable.yaml
@@ -1,2 +1,2 @@
 directive-arguments:
-- variable.c
+  - variable.c


### PR DESCRIPTION
Re-spin on the commits from #109 that did not go through.

It comprises 3 changes:

1. `parser: fix anonymous type detection` is the most contentious one. I still think what we have is 'broken' anyway so might as well be annoying but consistent / accurate for the time being.
This is the only one that has a bigger influence in the `cpp-initial-support` series, but I have an alternative fix if we opt for the status quo. That fix would belong to the other series though as is C++ specific.

2. `hawkmoth: add name appropriate configuration options` and its related clean-ups assume that the transformation rework is not done yet and leave `cautodoc_transformations` alone. If that were to go 1st, there will likely be some conflicts to address and commit messages to review.
Otherwise I think we're aligned on these.

3. Finally, the indentation thing, it's a matter of consistency for me, but it's purely cosmetic. Feel free to drop it.