### PR TITLE
C++ initial support v2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,18 +20,24 @@
 Hawkmoth - Sphinx Autodoc for C
 ===============================
 
-Hawkmoth is a minimalistic Sphinx_ `C Domain`_ autodoc directive extension to
-incorporate formatted C source code comments written in reStructuredText_ into
-Sphinx based documentation. It uses Clang Python Bindings for parsing, and
-generates C Domain directives for C API documentation, and more. In short,
-Hawkmoth is Sphinx Autodoc for C.
+Hawkmoth is a minimalistic Sphinx_ `C and C++ Domain`_ autodoc directive
+extension to incorporate formatted C or C++ source code comments written in
+reStructuredText_ into Sphinx based documentation. It uses Clang Python Bindings
+for parsing, and generates C or C++ Domain directives for C API documentation,
+and more. In short, Hawkmoth is Sphinx Autodoc for C/C++.
 
-Hawkmoth aims to be a compelling alternative for documenting C projects using
-Sphinx, mainly through its simplicity of design, implementation and use.
+.. attention::
+
+   C++ support is incomplete and highly experimental. Currently it supports C
+   syntax only and is definitely not usable, though we welcome testers and
+   bug reports / feature requests.
+
+Hawkmoth aims to be a compelling alternative for documenting C or C++ projects
+using Sphinx, mainly through its simplicity of design, implementation and use.
 
 .. _Sphinx: http://www.sphinx-doc.org
 
-.. _C Domain: http://www.sphinx-doc.org/en/stable/domains.html
+.. _C and C++ Domain: http://www.sphinx-doc.org/en/stable/domains.html
 
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -4,9 +4,10 @@ Directives
 ==========
 
 Hawkmoth provides several new directives for incorporating :ref:`documentation
-comments <syntax>` from C source files into the reStructuredText document. There
-are three main types of directives, for incorporating documentation from entire
-files, for single objects, and for composite objects optionally with members.
+comments <syntax>` from C/C++ source files into the reStructuredText document.
+There are three main types of directives, for incorporating documentation from
+entire files, for single objects, and for composite objects optionally with
+members.
 
 Source Files
 ------------
@@ -16,6 +17,7 @@ comments from any number of files. This is the most basic and quickest way to
 generate documentation, but offers no control over what gets included.
 
 .. rst:directive:: .. c:autodoc:: filename-pattern [...]
+.. rst:directive:: .. cpp:autodoc:: filename-pattern [...]
 
    Incorporate documentation comments from the files specified by the space
    separated list of filename patterns given as arguments. The patterns are
@@ -54,6 +56,7 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
 adding the ``file`` option.
 
 .. rst:directive:: .. c:autovar:: name
+.. rst:directive:: .. cpp:autovar:: name
 
    Incorporate the documentation comment for the variable ``name`` in the file
    ``file``.
@@ -73,6 +76,7 @@ adding the ``file`` option.
          :file: example_file.c
 
 .. rst:directive:: .. c:autotype:: name
+.. rst:directive:: .. cpp:autotype:: name
 
    Same as :rst:dir:`c:autovar` but for typedefs.
 
@@ -82,8 +86,17 @@ adding the ``file`` option.
          :file: example_file.c
 
 .. rst:directive:: .. c:automacro:: name
+.. rst:directive:: .. cpp:automacro:: name
 
    Same as :rst:dir:`c:autovar` but for macros, including function-like macros.
+
+   .. note::
+
+      :any:`sphinx:cpp-domain` does not have a ``cpp:macro`` directive, so all
+      macros are always in the C domain. The only known user limitation is that
+      references to said macros need to be done as (e.g.)
+      ``:c:macro:`EXAMPLE_MACRO``` even if the user used
+      :rst:dir:`cpp:automacro`. This is a Sphinx limitation.
 
    .. code-block:: rst
 
@@ -91,6 +104,7 @@ adding the ``file`` option.
          :file: example_file.c
 
 .. rst:directive:: .. c:autofunction:: name
+.. rst:directive:: .. cpp:autofunction:: name
 
    Same as :rst:dir:`c:autovar` but for functions. (Use :rst:dir:`c:automacro`
    for function-like macros.)
@@ -113,6 +127,7 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
 :rst:dir:`c:autofunction`, adding the ``members`` option.
 
 .. rst:directive:: .. c:autostruct:: name
+.. rst:directive:: .. cpp:autostruct:: name
 
    Incorporate the documentation comment for the structure ``name`` in the file
    ``file``, optionally including member documentation as specified by
@@ -148,6 +163,7 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
          :members: member_one, member_two
 
 .. rst:directive:: .. c:autounion:: name
+.. rst:directive:: .. cpp:autounion:: name
 
    Same as :rst:dir:`c:autostruct` but for unions.
 
@@ -158,6 +174,7 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
          :members: some_member
 
 .. rst:directive:: .. c:autoenum:: name
+.. rst:directive:: .. cpp:autoenum:: name
 
    Same as :rst:dir:`c:autostruct` but for enums. The enumeration constants are
    considered members and are included according to the ``members`` option.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,14 +1,21 @@
 Hawkmoth - Sphinx Autodoc for C
 ===============================
 
-Hawkmoth is a minimalistic Sphinx_ :any:`C Domain <sphinx:c-domain>` autodoc
-directive extension to incorporate formatted C source code comments written in
-reStructuredText_ into Sphinx based documentation. It uses Clang_ Python
-Bindings for parsing, and generates C Domain directives for C API documentation,
-and more. In short, Hawkmoth is Sphinx Autodoc for C.
+Hawkmoth is a minimalistic Sphinx_ :any:`C Domain <sphinx:c-domain>` and
+:any:`C++ Domain <sphinx:cpp-domain>` autodoc directive extension to incorporate
+formatted C or C++ source code comments written in reStructuredText_ into Sphinx
+based documentation. It uses Clang_ Python Bindings for parsing, and generates
+appropriate directives for C and C++ API documentation, and more. In short,
+Hawkmoth is Sphinx Autodoc for C/C++.
 
-Hawkmoth aims to be a compelling alternative for documenting C projects using
-Sphinx, mainly through its simplicity of design, implementation and use.
+.. attention::
+
+   C++ support is incomplete and highly experimental. Currently it supports C
+   syntax only and is definitely not usable, though we welcome testers and
+   bug reports / feature requests.
+
+Hawkmoth aims to be a compelling alternative for documenting C or C++ projects
+using Sphinx, mainly through its simplicity of design, implementation and use.
 
 Please see the `Hawkmoth project GitHub page`_ (or README.rst in the source
 repository) for information on how to obtain, install, and contribute to

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -3,9 +3,9 @@
 Syntax
 ======
 
-For the :any:`c:autodoc` directive to work, the C source code must be
-documented using specific documentation comment style, and the comments must
-follow reStructuredText markup.
+For any of the directives to work, the C or C++ source code must be documented
+using specific documentation comment style, and the comments must follow
+reStructuredText markup.
 
 Optionally, there's limited support for some Javadoc_ and Doxygen_ style
 constructs for compatibility.
@@ -16,7 +16,8 @@ and read on for documentation comment formatting details.
 Documentation Comments
 ----------------------
 
-Documentation comments are C language block comments that begin with ``/**``.
+Documentation comments are C/C++ language block comments that begin with
+``/**``.
 
 Because reStructuredText is sensitive about indentation, it's strongly
 recommended, even if not strictly required, to follow a uniform style for
@@ -38,12 +39,12 @@ One-line comments are fine too:
 
    /** The quick brown fox jumps over the lazy dog. */
 
-All documentation comments preceding C constructs are attached to them, and
-result in C Domain directives being added for them. This includes macros,
-functions, struct and union members, enumerations, etc.
+All documentation comments preceding C or C++ constructs are attached to them,
+and result in C or C++ Domain directives being added for them accordingly. This
+includes macros, functions, struct and union members, enumerations, etc.
 
 Documentation comments followed by comments (documentation or not) are included
-as generic documentation.
+as normal paragraphs in the order they appear.
 
 Tags
 ----
@@ -91,12 +92,13 @@ enable the support.
 
 .. _Doxygen: http://doxygen.nl/
 
-Cross-Referencing C Constructs
-------------------------------
+Cross-Referencing C and C++ Constructs
+--------------------------------------
 
-Use :any:`sphinx:c-domain` roles for cross-referencing as follows:
+Use :any:`sphinx:c-domain` or :any:`sphinx:cpp-domain` roles for
+cross-referencing as follows:
 
-- ``:c:data:`name``` for variables.
+- ``:c:var:`name``` for variables.
 
 - ``:c:func:`name``` for functions and function-like macros.
 

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -34,6 +34,7 @@ class _AutoBaseDirective(SphinxDirective):
     }
     has_content = False
 
+    _domain = None
     _docstring_types = None
 
     def __display_parser_diagnostics(self, errors):
@@ -100,7 +101,8 @@ class _AutoBaseDirective(SphinxDirective):
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
 
-        docstrings, errors = parse(filename, clang_args=clang_args)
+        docstrings, errors = parse(filename, domain=self._domain,
+                                   clang_args=clang_args)
 
         self.__display_parser_diagnostics(errors)
 
@@ -207,27 +209,34 @@ class _AutoCompoundDirective(_AutoSymbolDirective):
         return self.options.get('members', [])
 
 class CAutoDocDirective(_AutoDocDirective):
-    pass
+    _domain = 'c'
 
 class CAutoVarDirective(_AutoSymbolDirective):
+    _domain = 'c'
     _docstring_types = [docstring.VarDocstring]
 
 class CAutoTypeDirective(_AutoSymbolDirective):
+    _domain = 'c'
     _docstring_types = [docstring.TypeDocstring]
 
 class CAutoMacroDirective(_AutoSymbolDirective):
+    _domain = 'c'
     _docstring_types = [docstring.MacroDocstring, docstring.MacroFunctionDocstring]
 
 class CAutoFunctionDirective(_AutoSymbolDirective):
+    _domain = 'c'
     _docstring_types = [docstring.FunctionDocstring]
 
 class CAutoStructDirective(_AutoCompoundDirective):
+    _domain = 'c'
     _docstring_types = [docstring.StructDocstring]
 
 class CAutoUnionDirective(_AutoCompoundDirective):
+    _domain = 'c'
     _docstring_types = [docstring.UnionDocstring]
 
 class CAutoEnumDirective(_AutoCompoundDirective):
+    _domain = 'c'
     _docstring_types = [docstring.EnumDocstring]
 
 def _deprecate(conf, old, new, default=None):

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -87,7 +87,10 @@ class _AutoBaseDirective(SphinxDirective):
             lines[:] = [line for line in text.splitlines()]
 
     def __parse(self, filename):
-        clang_args = self.__get_clang_args()
+        # Always pass `-xc++` to the compiler on 'cpp' domain as the first
+        # option so that the user can override it.
+        clang_args = ['-xc++'] if self._domain == 'cpp' else []
+        clang_args.extend(self.__get_clang_args())
 
         # Cached parse results per rst document
         parsed_files = self.env.temp_data.setdefault('cautodoc_parsed_files', {})

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -239,6 +239,37 @@ class CAutoEnumDirective(_AutoCompoundDirective):
     _domain = 'c'
     _docstring_types = [docstring.EnumDocstring]
 
+class CppAutoDocDirective(_AutoDocDirective):
+    _domain = 'cpp'
+
+class CppAutoVarDirective(_AutoSymbolDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.VarDocstring]
+
+class CppAutoTypeDirective(_AutoSymbolDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.TypeDocstring]
+
+class CppAutoMacroDirective(_AutoSymbolDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.MacroDocstring, docstring.MacroFunctionDocstring]
+
+class CppAutoFunctionDirective(_AutoSymbolDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.FunctionDocstring]
+
+class CppAutoStructDirective(_AutoCompoundDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.StructDocstring]
+
+class CppAutoUnionDirective(_AutoCompoundDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.UnionDocstring]
+
+class CppAutoEnumDirective(_AutoCompoundDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.EnumDocstring]
+
 def _deprecate(conf, old, new, default=None):
     if conf[old]:
         logger = logging.getLogger(__name__)
@@ -274,6 +305,15 @@ def setup(app):
     app.add_directive_to_domain('c', 'autoenum', CAutoEnumDirective)
     app.add_directive_to_domain('c', 'automacro', CAutoMacroDirective)
     app.add_directive_to_domain('c', 'autofunction', CAutoFunctionDirective)
+
+    app.add_directive_to_domain('cpp', 'autodoc', CppAutoDocDirective)
+    app.add_directive_to_domain('cpp', 'autovar', CppAutoVarDirective)
+    app.add_directive_to_domain('cpp', 'autotype', CppAutoTypeDirective)
+    app.add_directive_to_domain('cpp', 'autostruct', CppAutoStructDirective)
+    app.add_directive_to_domain('cpp', 'autounion', CppAutoUnionDirective)
+    app.add_directive_to_domain('cpp', 'autoenum', CppAutoEnumDirective)
+    app.add_directive_to_domain('cpp', 'automacro', CppAutoMacroDirective)
+    app.add_directive_to_domain('cpp', 'autofunction', CppAutoFunctionDirective)
 
     return dict(version=__version__,
                 parallel_read_safe=True, parallel_write_safe=True)

--- a/hawkmoth/__main__.py
+++ b/hawkmoth/__main__.py
@@ -30,7 +30,11 @@ def main():
     from FILE, along with the generated C Domain directives, to standard
     output. Include metadata with verbose output.""")
     parser.add_argument('file', metavar='FILE', type=filename, action='store',
-                        help='The C source or header file to parse.')
+                        help='The C or C++ source or header file to parse.')
+    parser.add_argument('--domain',
+                        choices=['c', 'cpp'],
+                        default='c',
+                        help='Sphinx domain to be used.')
     parser.add_argument('--compat',
                         choices=['none',
                                  'javadoc-basic',
@@ -44,6 +48,7 @@ def main():
     args = parser.parse_args()
 
     comments, errors = parse(args.file, clang_args=args.clang)
+    comments, errors = parse(args.file, domain=args.domain, clang_args=args.clang)
 
     for comment in comments.walk():
         if args.verbose:

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -50,8 +50,8 @@ class Docstring():
     _indent = 0
     _fmt = ''
 
-    def __init__(self, text=None, name=None, decl_name=None,
-                 ttype=None, args=None, meta=None, nest=0):
+    def __init__(self, domain='c', text=None, name=None,
+                 decl_name=None, ttype=None, args=None, meta=None, nest=0):
         self._text = text
         self._name = name
         self._decl_name = decl_name
@@ -59,6 +59,7 @@ class Docstring():
         self._args = args
         self._meta = meta
         self._nest = nest
+        self._domain = domain
         self._children = []
 
     def add_child(self, comment):
@@ -101,7 +102,7 @@ class Docstring():
 
     def _get_header_lines(self):
         name = self._get_decl_name()
-
+        domain = self._domain
         ttype = self._ttype
 
         spacer = ''
@@ -113,7 +114,7 @@ class Docstring():
             arg_fmt = lambda t, n: f"{t}{'' if len(t) == 0 or t.endswith('*') else ' '}{n}"
             args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
-        header = self._fmt.format(name=name, ttype=ttype,
+        header = self._fmt.format(domain=domain, name=name, ttype=ttype,
                                   type_spacer=spacer, args=args)
 
         return header.splitlines()
@@ -190,11 +191,11 @@ class TextDocstring(Docstring):
 
 class VarDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:var:: {ttype}{type_spacer}{name}\n\n'
+    _fmt = '\n.. {domain}:var:: {ttype}{type_spacer}{name}\n\n'
 
 class TypeDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:type:: {name}\n\n'
+    _fmt = '\n.. {domain}:type:: {name}\n\n'
 
 class _CompoundDocstring(Docstring):
     def _get_decl_name(self):
@@ -210,23 +211,23 @@ class _CompoundDocstring(Docstring):
 
 class StructDocstring(_CompoundDocstring):
     _indent = 1
-    _fmt = '\n.. c:struct:: {name}\n\n'
+    _fmt = '\n.. {domain}:struct:: {name}\n\n'
 
 class UnionDocstring(_CompoundDocstring):
     _indent = 1
-    _fmt = '\n.. c:union:: {name}\n\n'
+    _fmt = '\n.. {domain}:union:: {name}\n\n'
 
 class EnumDocstring(_CompoundDocstring):
     _indent = 1
-    _fmt = '\n.. c:enum:: {name}\n\n'
+    _fmt = '\n.. {domain}:enum:: {name}\n\n'
 
 class EnumeratorDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:enumerator:: {name}\n\n'
+    _fmt = '\n.. {domain}:enumerator:: {name}\n\n'
 
 class MemberDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:member:: {ttype}{type_spacer}{name}\n\n'
+    _fmt = '\n.. {domain}:member:: {ttype}{type_spacer}{name}\n\n'
 
 class MacroDocstring(Docstring):
     _indent = 1
@@ -238,4 +239,4 @@ class MacroFunctionDocstring(Docstring):
 
 class FunctionDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. c:function:: {ttype}{type_spacer}{name}({args})\n\n'
+    _fmt = '\n.. {domain}:function:: {ttype}{type_spacer}{name}({args})\n\n'

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -438,7 +438,7 @@ def _parse_undocumented_block(domain, comments, errors, cursor, nest):
     return ret
 
 # Parse a file and return a tree of docstring.Docstring objects.
-def parse(filename, domain='c', clang_args=None):
+def parse(filename, domain=None, clang_args=None):
     errors = []
     index = Index.create()
 

--- a/test/autoenum.yaml
+++ b/test/autoenum.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autoenum
 directive-arguments:
   - foo

--- a/test/autostruct-no-members.yaml
+++ b/test/autostruct-no-members.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autostruct
 directive-arguments:
   - sample_struct

--- a/test/autostruct.yaml
+++ b/test/autostruct.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autostruct
 directive-arguments:
   - sample_struct

--- a/test/autovariable-fnptr-array.yaml
+++ b/test/autovariable-fnptr-array.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autovar
 directive-arguments:
   - function_pointer_array

--- a/test/clang-diagnostics.yaml
+++ b/test/clang-diagnostics.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - clang-diagnostics.c

--- a/test/comment-strip.yaml
+++ b/test/comment-strip.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - comment-strip.c

--- a/test/composition.yaml
+++ b/test/composition.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - composition.c

--- a/test/cpp-autoenum.rst
+++ b/test/cpp-autoenum.rst
@@ -1,0 +1,10 @@
+
+.. cpp:enum:: foo
+
+   Enum doc.
+
+
+   .. cpp:enumerator:: bar
+
+      Enumeration comment.
+

--- a/test/cpp-autoenum.yaml
+++ b/test/cpp-autoenum.yaml
@@ -1,0 +1,8 @@
+domain: cpp
+directive: autoenum
+directive-arguments:
+  - foo
+directive-options:
+  file: enum.c
+  members:
+    - bar

--- a/test/cpp-autostruct-no-members.rst
+++ b/test/cpp-autostruct-no-members.rst
@@ -1,0 +1,7 @@
+
+.. cpp:struct:: sample_struct
+
+   This is a sample struct
+
+   Woohoo.
+

--- a/test/cpp-autostruct-no-members.yaml
+++ b/test/cpp-autostruct-no-members.yaml
@@ -1,0 +1,6 @@
+domain: cpp
+directive: autostruct
+directive-arguments:
+  - sample_struct
+directive-options:
+  file: struct.c

--- a/test/cpp-autostruct.rst
+++ b/test/cpp-autostruct.rst
@@ -1,0 +1,24 @@
+
+.. cpp:struct:: sample_struct
+
+   This is a sample struct
+
+   Woohoo.
+
+
+   .. cpp:member:: int array_member[5]
+
+      array member
+
+
+   .. cpp:member:: int (*function_pointer_member)(int, int)
+
+      function pointer member with parameter names omitted
+
+
+   .. cpp:member:: int (*other_function_pointer_member)(int foo, int bar)
+
+      function pointer member with parameter names
+
+      :param foo: the foo
+      :param bar: the bar

--- a/test/cpp-autostruct.yaml
+++ b/test/cpp-autostruct.yaml
@@ -1,0 +1,10 @@
+domain: cpp
+directive: autostruct
+directive-arguments:
+  - sample_struct
+directive-options:
+  file: struct.c
+  members:
+    - array_member
+    - function_pointer_member
+    - other_function_pointer_member

--- a/test/cpp-autovariable-fnptr-array.rst
+++ b/test/cpp-autovariable-fnptr-array.rst
@@ -1,0 +1,5 @@
+
+.. cpp:var::  void (*function_pointer_array[5])(void)
+
+   array of function pointers
+

--- a/test/cpp-autovariable-fnptr-array.yaml
+++ b/test/cpp-autovariable-fnptr-array.yaml
@@ -1,0 +1,6 @@
+domain: cpp
+directive: autovar
+directive-arguments:
+  - function_pointer_array
+directive-options:
+  file: variable.c

--- a/test/cpp-clang-diagnostics.rst
+++ b/test/cpp-clang-diagnostics.rst
@@ -1,0 +1,5 @@
+
+.. cpp:function:: int frob(struct list *list, enum mode mode)
+
+   struct list and enum mode aren't declared.
+

--- a/test/cpp-clang-diagnostics.stderr
+++ b/test/cpp-clang-diagnostics.stderr
@@ -1,0 +1,1 @@
+ERROR: clang-diagnostics.c:4: ISO C++ forbids forward references to 'enum' types

--- a/test/cpp-clang-diagnostics.yaml
+++ b/test/cpp-clang-diagnostics.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - clang-diagnostics.c

--- a/test/cpp-comment-strip.rst
+++ b/test/cpp-comment-strip.rst
@@ -1,0 +1,111 @@
+
+.. cpp:function:: int space_star_space(int foo, int bar)
+
+   Recommended formatting.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. cpp:function:: int no_prefix(int foo, int bar)
+
+   No prefix at all.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. cpp:function:: int space_prefix(int foo, int bar)
+
+   Prefix with spaces.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. cpp:function:: int tab(int foo, int bar)
+
+   Tab prefix.
+
+   :param foo: foo
+           continuation with tab
+   :param foo: bar
+           continuation with tab
+
+
+.. cpp:function:: int tab_first_line_content(int foo, int bar)
+
+   Tab prefix, content on first line.
+
+   :param foo: foo
+           continuation with tab
+   :param foo: bar
+           continuation with tab
+
+
+.. cpp:function:: int space_star_space_first_line_content(int foo, int bar)
+
+   Not recommended.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. cpp:function:: int space_star(int foo, int bar)
+
+   Not recommended.
+
+   :param foo: foo
+     continuation with spaces
+   :param bar: bar
+     continuation with spaces
+
+
+.. cpp:function:: int no_prefix_star_bullets(int foo, int bar)
+
+   No prefix, bulleted list:
+
+   * Bullet foo.
+   * Bullet bar.
+
+
+.. cpp:function:: int space_star_space_star_bullets(int foo, int bar)
+
+   Normal, bulleted list:
+
+   * Bullet foo.
+   * Bullet bar.
+
+
+.. cpp:function:: int blank_lines(int foo, int bar)
+
+   Leading and trailing blank line removal.
+
+
+.. cpp:function:: int one_liner(int foo, int bar)
+
+   One line comment.
+
+
+.. cpp:function:: int one_liner_whitespace(int foo, int bar)
+
+   One line comment with leading and trailing whitespace.
+
+
+.. cpp:function:: int two_liner(int foo, int bar)
+
+   Two line comment.
+
+
+.. cpp:function:: int two_liner_whitespace(int foo, int bar)
+
+   Two line comment with leading and trailing whitespace.
+

--- a/test/cpp-comment-strip.yaml
+++ b/test/cpp-comment-strip.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - comment-strip.c

--- a/test/cpp-composition.rst
+++ b/test/cpp-composition.rst
@@ -1,0 +1,16 @@
+
+This is a file level comment.
+
+
+.. cpp:var:: int a
+
+   This is a variable.
+
+
+.. cpp:var:: int b
+
+   This is another variable.
+
+
+This is another file level comment.
+

--- a/test/cpp-composition.yaml
+++ b/test/cpp-composition.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - composition.c

--- a/test/cpp-doc.rst
+++ b/test/cpp-doc.rst
@@ -1,0 +1,3 @@
+
+This is a top level comment.
+

--- a/test/cpp-doc.yaml
+++ b/test/cpp-doc.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - doc.c

--- a/test/cpp-enum.rst
+++ b/test/cpp-enum.rst
@@ -1,0 +1,30 @@
+
+.. cpp:enum:: foo
+
+   Enum doc.
+
+
+   .. cpp:enumerator:: bar
+
+      Enumeration comment.
+
+
+   .. cpp:enumerator:: baz
+
+      Another.
+
+
+.. cpp:enum:: @anonymous_ef849cb791c3c921354e4b05dcefedfa
+
+   Anonymous enum.
+
+
+   .. cpp:enumerator:: FOO
+
+      Enumeration comment.
+
+
+   .. cpp:enumerator:: BAR
+
+      Another.
+

--- a/test/cpp-enum.yaml
+++ b/test/cpp-enum.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - enum.c

--- a/test/cpp-function-like-macro.rst
+++ b/test/cpp-function-like-macro.rst
@@ -1,0 +1,10 @@
+
+.. c:macro:: FOO(bar, baz)
+
+   A function-like macro.
+
+
+.. c:macro:: BAR()
+
+   Another
+

--- a/test/cpp-function-like-macro.yaml
+++ b/test/cpp-function-like-macro.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - function-like-macro.c

--- a/test/cpp-function.rst
+++ b/test/cpp-function.rst
@@ -1,0 +1,42 @@
+
+.. cpp:function:: int foo(int bar, int baz)
+
+   Foo function.
+
+
+.. cpp:function:: int no_parameters(void)
+
+   No parameters.
+
+
+.. cpp:function:: int empty_parameter_list(void)
+
+   Empty parameter list.
+
+
+.. cpp:function:: int variadic(const char *fmt, ...)
+
+   Variadic function.
+
+
+.. cpp:function:: void foorray(const double array[], int x[5])
+
+   Array parameters.
+
+
+.. cpp:function:: void multi_array_param(int x[2][2], int y[2][2])
+
+   Array parameters with multiple dimensions.
+
+   Clang removes spaces.
+
+
+.. cpp:function:: void function_pointer_param(void *(*hook)(void *p, int n))
+
+   Function pointer parameter.
+
+
+.. cpp:function:: void array_of_pointer_params(char *p[])
+
+   Array of pointers parameter.
+

--- a/test/cpp-function.yaml
+++ b/test/cpp-function.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - function.c

--- a/test/cpp-meta-expected-failure.rst
+++ b/test/cpp-meta-expected-failure.rst
@@ -1,0 +1,3 @@
+
+Meta test: This fails.
+

--- a/test/cpp-meta-expected-failure.yaml
+++ b/test/cpp-meta-expected-failure.yaml
@@ -1,0 +1,4 @@
+domain: cpp
+directive-arguments:
+  - meta-expected-failure.c
+expected-failure: true

--- a/test/cpp-mixed-linkage.cpp
+++ b/test/cpp-mixed-linkage.cpp
@@ -1,0 +1,15 @@
+/** C++ function. */
+int foo(void);
+
+/** Top level docstring 1. */
+extern "C" {
+
+/** Top level docstring 2. */
+
+/** C function. */
+int bar(void);
+
+}
+
+/** Another C++ function. */
+int baz(void);

--- a/test/cpp-mixed-linkage.rst
+++ b/test/cpp-mixed-linkage.rst
@@ -1,0 +1,21 @@
+
+.. cpp:function:: int foo(void)
+
+   C++ function.
+
+
+Top level docstring 1.
+
+
+Top level docstring 2.
+
+
+.. c:function:: int bar(void)
+
+   C function.
+
+
+.. cpp:function:: int baz(void)
+
+   Another C++ function.
+

--- a/test/cpp-mixed-linkage.yaml
+++ b/test/cpp-mixed-linkage.yaml
@@ -1,0 +1,5 @@
+domain: cpp
+directive-arguments:
+  - cpp-mixed-linkage.cpp
+example-title: Mixed C/C++ linkage
+example-priority: 1

--- a/test/cpp-simple-macro.rst
+++ b/test/cpp-simple-macro.rst
@@ -1,0 +1,15 @@
+
+.. c:macro:: I_EXIST
+
+   The simplest macro.
+
+
+.. c:macro:: FOO
+
+   A simple macro.
+
+
+.. c:macro:: BAR
+
+   Another simple macro.
+

--- a/test/cpp-simple-macro.yaml
+++ b/test/cpp-simple-macro.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - simple-macro.c

--- a/test/cpp-struct.rst
+++ b/test/cpp-struct.rst
@@ -1,0 +1,80 @@
+
+.. cpp:struct:: sample_struct
+
+   This is a sample struct
+
+   Woohoo.
+
+
+   .. cpp:member:: int jesh
+
+      member
+
+
+   .. cpp:member:: int array_member[5]
+
+      array member
+
+
+   .. cpp:member:: void *pointer_member
+
+      pointer member
+
+
+   .. cpp:member:: int (*function_pointer_member)(int, int)
+
+      function pointer member with parameter names omitted
+
+
+   .. cpp:member:: int (*other_function_pointer_member)(int foo, int bar)
+
+      function pointer member with parameter names
+
+      :param foo: the foo
+      :param bar: the bar
+
+
+   .. cpp:member:: struct sample_struct *next
+
+      foo next
+
+
+.. cpp:struct:: @anonymous_7bf120438d254a91e1275b973de6a0eb
+
+   Anonymous struct documentation.
+
+
+   .. cpp:member:: int foo
+
+      Struct member.
+
+
+.. cpp:struct:: foo_struct
+
+   Named struct.
+
+
+   .. cpp:struct:: @anonymous_a63d10331be1a527625db63b8ace540f
+
+      Anonymous sub-struct.
+
+
+      .. cpp:member:: int foo_member
+
+         Member foo.
+
+
+   .. cpp:union:: @anonymous_69382278a84175c1cbff40d522114b38
+
+      Anonymous sub-union.
+
+
+      .. cpp:member:: int bar_member_1
+
+         Member bar 1.
+
+
+      .. cpp:member:: int bar_member_2
+
+         Member bar 2.
+

--- a/test/cpp-struct.yaml
+++ b/test/cpp-struct.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - struct.c

--- a/test/cpp-test.cpp
+++ b/test/cpp-test.cpp
@@ -1,0 +1,78 @@
+/** This is a top level comment from the code. */
+
+/** Macro. */
+#define FOO
+
+/** Function like macro. */
+#define FOOING(x) x
+
+/**
+ * Function.
+ *
+ * :param bar: Some parameter.
+ * :param baz: Some other parameter.
+ *
+ * A link to a struct documentation from the code :cpp:any:`stfoo`.
+ */
+int foo(int bar, int baz);
+
+/** Variable. */
+int fooer;
+
+/** Struct. */
+struct stfoo {
+	/** Member. */
+	int foo;
+};
+
+/** Enum. */
+enum somefoos {
+	/** one */
+	FOO1,
+	/** two */
+	FOO2,
+	/** three */
+	FOO3,
+};
+
+/** Anonymous structure. */
+struct {
+	/** Anonymous sub-struct. */
+	struct {
+		/** Member foo. */
+		int foo_member;
+	} foo;
+
+	/** Anonymous sub-union. */
+	union {
+		/** Member bar 1. */
+		int bar_member_1;
+		/** Member bar 2. */
+		int bar_member_2;
+	} bar;
+} alt_stfoo_var;
+
+/** Membering. */
+int (*foopointer)(int, int);
+
+/** Memberings. */
+int (*foopointers[5])(int, int);
+
+/** Union. */
+union foonion {
+
+	/** Member. */
+	int foo;
+
+	/** Member. */
+	int bar;
+
+	/** Member member. */
+	struct stfoo member_berry;
+
+	/** Membering. */
+	int (*foomember)(int, int);
+
+	/** Memberings. */
+	int (*foomembers[5])(int, int);
+};

--- a/test/cpp-typedef-enum.rst
+++ b/test/cpp-typedef-enum.rst
@@ -1,0 +1,20 @@
+
+.. cpp:enum:: named
+
+   named typedeffed enum
+
+
+   .. cpp:enumerator:: damn
+
+      named enumeration
+
+
+.. cpp:enum:: @anonymous_90372874a3c8c25dccf983612f39e93f
+
+   unnamed typedeffed enum
+
+
+   .. cpp:enumerator:: shit
+
+      unnamed enumeration
+

--- a/test/cpp-typedef-enum.yaml
+++ b/test/cpp-typedef-enum.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - typedef-enum.c

--- a/test/cpp-typedef-struct.rst
+++ b/test/cpp-typedef-struct.rst
@@ -1,0 +1,20 @@
+
+.. cpp:struct:: named
+
+   named typedeffed struct
+
+
+   .. cpp:member:: int m
+
+      named member
+
+
+.. cpp:struct:: @anonymous_7f9a1d628cd33f3227f3fcdc3a405aa6
+
+   unnamed typedeffed struct
+
+
+   .. cpp:member:: int m
+
+      unnamed member
+

--- a/test/cpp-typedef-struct.yaml
+++ b/test/cpp-typedef-struct.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - typedef-struct.c

--- a/test/cpp-typedef.rst
+++ b/test/cpp-typedef.rst
@@ -1,0 +1,5 @@
+
+.. cpp:type:: boo
+
+   Typedef comment.
+

--- a/test/cpp-typedef.yaml
+++ b/test/cpp-typedef.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - typedef.c

--- a/test/cpp-union.rst
+++ b/test/cpp-union.rst
@@ -1,0 +1,20 @@
+
+.. cpp:union:: foo
+
+   Union documentation.
+
+
+   .. cpp:member:: int foo
+
+      int member 1.
+
+
+   .. cpp:member:: int bar
+
+      int member 2.
+
+
+   .. cpp:struct:: _baz
+
+      struct member.
+

--- a/test/cpp-union.yaml
+++ b/test/cpp-union.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - union.c

--- a/test/cpp-variable.rst
+++ b/test/cpp-variable.rst
@@ -1,0 +1,60 @@
+
+.. cpp:var:: int sheesh
+
+   This is a variable document.
+
+
+.. cpp:var:: int (*function_pointer_variable)(int *param_name_ignored)
+
+   function pointer variable
+
+
+.. cpp:var:: int (*variadic_function_pointer_variable)(int *param_name_ignored, ...)
+
+   variadic function pointer variable
+
+
+.. cpp:var:: int (**pointer_to_function_pointer_variable)(int)
+
+   pointer to function pointer variable
+
+
+.. cpp:var:: void (*function_pointer_array[5])(void)
+
+   array of function pointers
+
+
+.. cpp:var:: void (*array_of_function_pointer_array[5][15])(void)
+
+   array of array of function pointers
+
+
+.. cpp:var:: const char *(*const function_pointer_with_qualifier)(const char *in)
+
+   function pointer with lots of const qualifiers
+
+
+.. cpp:var:: const char *(*const volatile function_pointer_with_multiple_qualifiers)(const char *in)
+
+   function pointer with multiple qualifiers
+
+
+.. cpp:var:: const char *(*const *volatile *const legal_type_involving_function_pointer[2][2])(const char *in)
+
+   a complex type involving function pointers somehow
+
+
+.. cpp:var:: int (*function_pointer_with_function_pointer_arg)( float (*arg1)(char c))
+
+   function pointer to a function taking a function pointer as arg
+
+
+.. cpp:var:: char *array_of_pointers[1]
+
+   Array of pointers.
+
+
+.. cpp:var:: int multi_dim[1][2]
+
+   Multi-dimensional array.
+

--- a/test/cpp-variable.yaml
+++ b/test/cpp-variable.yaml
@@ -1,0 +1,3 @@
+domain: cpp
+directive-arguments:
+  - variable.c

--- a/test/cpp-wrong-syntax.h
+++ b/test/cpp-wrong-syntax.h
@@ -1,0 +1,3 @@
+/** C++ class inside a '.h'. */
+class foo {
+};

--- a/test/cpp-wrong-syntax.rst
+++ b/test/cpp-wrong-syntax.rst
@@ -1,0 +1,5 @@
+
+.. c:var:: int foo
+
+   C++ class inside a '.h'.
+

--- a/test/cpp-wrong-syntax.stderr
+++ b/test/cpp-wrong-syntax.stderr
@@ -1,0 +1,2 @@
+ERROR: cpp-wrong-syntax.h:2: unknown type name 'class'
+ERROR: cpp-wrong-syntax.h:2: expected ';' after top level declarator

--- a/test/cpp-wrong-syntax.yaml
+++ b/test/cpp-wrong-syntax.yaml
@@ -1,0 +1,5 @@
+domain: c
+directive-arguments:
+  - cpp-wrong-syntax.h
+example-title: C++ syntax in C source
+example-priority: 1

--- a/test/doc.yaml
+++ b/test/doc.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - doc.c

--- a/test/enum.yaml
+++ b/test/enum.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - enum.c

--- a/test/example-autodoc.yaml
+++ b/test/example-autodoc.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-autodoc.c
 example-title: Overview

--- a/test/example-autofunction.yaml
+++ b/test/example-autofunction.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autofunction
 directive-arguments:
   - frob

--- a/test/example-automacro.yaml
+++ b/test/example-automacro.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: automacro
 directive-arguments:
   - DIE

--- a/test/example-autostruct.yaml
+++ b/test/example-autostruct.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autostruct
 directive-arguments:
   - list

--- a/test/example-autounion.yaml
+++ b/test/example-autounion.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autounion
 directive-arguments:
   - onion

--- a/test/example-autovar.yaml
+++ b/test/example-autovar.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autovar
 directive-arguments:
   - meaning_of_life

--- a/test/example-compat.yaml
+++ b/test/example-compat.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-compat.c
 directive-options:

--- a/test/example-enum.yaml
+++ b/test/example-enum.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autoenum
 directive-arguments:
   - mode

--- a/test/example-function.yaml
+++ b/test/example-function.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-function.c
 example-title: Function

--- a/test/example-macro.yaml
+++ b/test/example-macro.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-macro.c
 example-title: Macro

--- a/test/example-preprocessor.yaml
+++ b/test/example-preprocessor.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-preprocessor.c
 directive-options:

--- a/test/example-struct.yaml
+++ b/test/example-struct.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-struct.c
 example-title: Struct

--- a/test/example-transform.yaml
+++ b/test/example-transform.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-transform.c
 directive-options:

--- a/test/example-typedef.yaml
+++ b/test/example-typedef.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive: autotype
 directive-arguments:
   - list_data_t

--- a/test/example-variable.yaml
+++ b/test/example-variable.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - example-variable.c
 example-title: Variable

--- a/test/function-like-macro.yaml
+++ b/test/function-like-macro.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - function-like-macro.c

--- a/test/function.yaml
+++ b/test/function.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - function.c

--- a/test/meta-expected-failure.yaml
+++ b/test/meta-expected-failure.yaml
@@ -1,3 +1,4 @@
+domain: c
 directive-arguments:
   - meta-expected-failure.c
 expected-failure: true

--- a/test/restrict.c
+++ b/test/restrict.c
@@ -1,0 +1,11 @@
+/** 'restrict' pointer. */
+int *restrict restrict_ptr;
+
+/** A weirder pointer. */
+const int *const restrict *restrict slightly_weirder_ptr[4][2];
+
+/** A complex pointer type that is only legal in C. */
+const char* (*const *volatile *restrict legal_type_involving_function_pointer[12][3])(const char *restrict in);
+
+/** Function with heavily qualified argument. */
+int picky_function(const char *restrict not_your_avg_ptr);

--- a/test/restrict.rst
+++ b/test/restrict.rst
@@ -1,0 +1,20 @@
+
+.. c:var:: int *restrict restrict_ptr
+
+   'restrict' pointer.
+
+
+.. c:var:: const int *const restrict *restrict slightly_weirder_ptr[4][2]
+
+   A weirder pointer.
+
+
+.. c:var:: const char *(*const *volatile *restrict legal_type_involving_function_pointer[12][3])(const char *restrict in)
+
+   A complex pointer type that is only legal in C.
+
+
+.. c:function:: int picky_function(const char *restrict not_your_avg_ptr)
+
+   Function with heavily qualified argument.
+

--- a/test/restrict.yaml
+++ b/test/restrict.yaml
@@ -1,0 +1,3 @@
+domain: c
+directive-arguments:
+  - restrict.c

--- a/test/simple-macro.yaml
+++ b/test/simple-macro.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - simple-macro.c

--- a/test/struct.yaml
+++ b/test/struct.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - struct.c

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -50,6 +50,7 @@ def _get_output(testcase, monkeypatch, capsys, **options):
     domain = options.get('domain')
     if domain is not None:
         args += [f'--domain={domain}']
+        args += [f'--clang={"-xc++" if domain == "cpp" else "-xc"}']
 
     directive_options = options.get('directive-options', {})
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -47,13 +47,17 @@ def _get_output(testcase, monkeypatch, capsys, **options):
     if directive:
         pytest.skip(f'{directive} directive test')
 
-    options = options.get('directive-options', {})
+    domain = options.get('domain')
+    if domain is not None:
+        args += [f'--domain={domain}']
 
-    transform = options.get('transform', None)
+    directive_options = options.get('directive-options', {})
+
+    transform = directive_options.get('transform')
     if transform is not None:
         pytest.skip('cli does not support generic transformations')
 
-    clang_args = options.get('clang')
+    clang_args = directive_options.get('clang')
     if clang_args:
         args += [f'--clang={clang_arg}' for clang_arg in clang_args]
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -19,6 +19,8 @@ def _get_output(testcase, **options):
     docs_str = ''
     errors_str = ''
 
+    domain = options.get('domain')
+
     directive = options.get('directive')
     if directive:
         pytest.skip(f'{directive} directive test')
@@ -28,7 +30,7 @@ def _get_output(testcase, **options):
     options = options.get('directive-options', {})
 
     clang_args = options.get('clang')
-    comments, errors = parse(input_filename, clang_args=clang_args)
+    comments, errors = parse(input_filename, domain=domain, clang_args=clang_args)
 
     tropt = options.pop('transform', None)
     if tropt is not None:

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -21,6 +21,11 @@ def _get_output(testcase, **options):
 
     domain = options.get('domain')
 
+    # Default to compile as C++ if the test is for the C++ domain so that we can
+    # use C sources for C++ tests. The yaml may override this in cases where we
+    # want to force a mismatch.
+    clang_args = ['-xc++'] if domain == 'cpp' else ['-xc']
+
     directive = options.get('directive')
     if directive:
         pytest.skip(f'{directive} directive test')
@@ -29,7 +34,7 @@ def _get_output(testcase, **options):
 
     options = options.get('directive-options', {})
 
-    clang_args = options.get('clang')
+    clang_args.extend(options.get('clang', []))
     comments, errors = parse(input_filename, domain=domain, clang_args=clang_args)
 
     tropt = options.pop('transform', None)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -25,6 +25,7 @@ def get_testcases(path):
             yield os.path.join(path, f)
 
 options_schema = strictyaml.Map({
+    'domain': strictyaml.Enum(['c', 'cpp']),
     strictyaml.Optional('directive'): strictyaml.Str(),
     strictyaml.Optional('directive-arguments'): strictyaml.Seq(strictyaml.Str()),
     strictyaml.Optional('directive-options'): strictyaml.Map({
@@ -63,11 +64,12 @@ def get_input_filename(options, path=None):
         return basename
 
 def get_directive_string(options):
+    domain = options.get('domain', None)
     directive = options.get('directive', 'autodoc')
     arguments = options.get('directive-arguments', [])
     arguments_str = ' '.join(arguments)
 
-    directive_str = f'.. c:{directive}:: {arguments_str}\n'
+    directive_str = f'.. {domain}:{directive}:: {arguments_str}\n'
 
     directive_options = options.get('directive-options', {})
 

--- a/test/typedef-enum.yaml
+++ b/test/typedef-enum.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - typedef-enum.c

--- a/test/typedef-struct.yaml
+++ b/test/typedef-struct.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - typedef-struct.c

--- a/test/typedef.yaml
+++ b/test/typedef.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - typedef.c

--- a/test/union.yaml
+++ b/test/union.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - union.c

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -64,12 +64,13 @@ def print_source(input_filename):
 
 def print_example(testcase):
     options = testenv.get_testcase_options(testcase)
+    domain = options.get('domain')
 
     if options.get('example-use-namespace'):
         namespace = 'namespace_' + hashlib.md5(f'{testcase}'.encode()).hexdigest()
 
-        namespace_push = f'.. c:namespace-push:: {namespace}\n\n'
-        namespace_pop = '\n.. c:namespace-pop::\n'
+        namespace_push = f'.. {domain}:namespace-push:: {namespace}\n\n'
+        namespace_pop = '\n.. {domain}:namespace-pop::\n'
     else:
         namespace_push = ''
         namespace_pop = ''

--- a/test/variable.c
+++ b/test/variable.c
@@ -28,20 +28,36 @@ void (*function_pointer_array[5])(void);
  */
 void (*array_of_function_pointer_array[5][15])(void);
 
+/* Boilerplate to pacify the compiler. */
+const char *boilerplate_fn0(const char *s);
+
 /**
  * function pointer with lots of const qualifiers
  */
-const char* (*const function_pointer_with_qualifier)(const char *in);
+const char* (*const function_pointer_with_qualifier)(const char *in) = &boilerplate_fn0;
 
 /**
  * function pointer with multiple qualifiers
  */
-const char* (*const volatile function_pointer_with_multiple_qualifiers)(const char *in);
+const char* (*const volatile function_pointer_with_multiple_qualifiers)(const char *in) = &boilerplate_fn0;
+
+/* Some more boilerplate. */
+const char* (*const boilerplate_fn_ptr)(const char *in) = &boilerplate_fn0;
+const char* (*const *volatile boilerplate_fn_ptr0)(const char *in) = &boilerplate_fn_ptr;
 
 /**
  * a complex type involving function pointers somehow
  */
-const char* (*const *volatile *const legal_type_involving_function_pointer[12][3])(const char *in);
+const char* (*const *volatile *const legal_type_involving_function_pointer[2][2])(const char *in) = {
+	{
+		&boilerplate_fn_ptr0,
+		&boilerplate_fn_ptr0,
+	},
+	{
+		&boilerplate_fn_ptr0,
+		&boilerplate_fn_ptr0,
+	},
+};
 
 /**
  * function pointer to a function taking a function pointer as arg

--- a/test/variable.c
+++ b/test/variable.c
@@ -41,7 +41,7 @@ const char* (*const volatile function_pointer_with_multiple_qualifiers)(const ch
 /**
  * a complex type involving function pointers somehow
  */
-const char* (*const *volatile *restrict legal_type_involving_function_pointer[12][3])(const char *in);
+const char* (*const *volatile *const legal_type_involving_function_pointer[12][3])(const char *in);
 
 /**
  * function pointer to a function taking a function pointer as arg

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -39,7 +39,7 @@
    function pointer with multiple qualifiers
 
 
-.. c:var:: const char *(*const *volatile *const legal_type_involving_function_pointer[12][3])(const char *in)
+.. c:var:: const char *(*const *volatile *const legal_type_involving_function_pointer[2][2])(const char *in)
 
    a complex type involving function pointers somehow
 

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -39,7 +39,7 @@
    function pointer with multiple qualifiers
 
 
-.. c:var:: const char *(*const *volatile *restrict legal_type_involving_function_pointer[12][3])(const char *in)
+.. c:var:: const char *(*const *volatile *const legal_type_involving_function_pointer[12][3])(const char *in)
 
    a complex type involving function pointers somehow
 

--- a/test/variable.yaml
+++ b/test/variable.yaml
@@ -1,2 +1,3 @@
+domain: c
 directive-arguments:
   - variable.c


### PR DESCRIPTION
V2 of #116. There are a ton of small changes and some bigger ones.

Notably (apologies if I forget any major change):
- test: mass addition of cpp domain tests                          
  - Files renamed to somehow control the mayhem. Didn't do the same for C tests as that would entail too much noise.
- test: add default compiler options according to the test domain  
  - Optional. I'm not 100% confident it's an improvement, but it does reduce verbosity in the yaml files.
  - If dropped, the cpp-* tests will be broken until the clang options are fixed accordingly.
- test: fix test so it produces no error messages                  
  - Fixes the issue with older Clang producing different white space in some error messages.
- test: fix C test that breaks C++ compilation                     
  - Separates `restrict` stuff into its own test.
- parser: add mixed domain support                                                             
  - New function handles blocks that are always undocumented in a more obvious way.
  - Right now this is only the `extern "C"`, but will be helpful in handling namespaces in C++ as well. I should say I didn't test it yet, but I'm quite confident it will go that way.
  - This will still ignore blocks that could be documented and the user elects not to. E.g. documented members of a structure that has no docstring itself will be skipped.