### PR TITLE
C++ type support

### DIFF
--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -273,6 +273,10 @@ class CppAutoEnumDirective(_AutoCompoundDirective):
     _domain = 'cpp'
     _docstring_types = [docstring.EnumDocstring]
 
+class CppAutoClassDirective(_AutoCompoundDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.ClassDocstring]
+
 def _deprecate(conf, old, new, default=None):
     if conf[old]:
         logger = logging.getLogger(__name__)
@@ -317,6 +321,7 @@ def setup(app):
     app.add_directive_to_domain('cpp', 'autoenum', CppAutoEnumDirective)
     app.add_directive_to_domain('cpp', 'automacro', CppAutoMacroDirective)
     app.add_directive_to_domain('cpp', 'autofunction', CppAutoFunctionDirective)
+    app.add_directive_to_domain('cpp', 'autoclass', CppAutoClassDirective)
 
     return dict(version=__version__,
                 parallel_read_safe=True, parallel_write_safe=True)

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-2021 Jani Nikula <jani@nikula.org>
-# Copyright (c) 2018-2022 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
+# Copyright (c) 2018-2023 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 """
 Documentation comment storage and converter
@@ -51,12 +51,14 @@ class Docstring():
     _fmt = ''
 
     def __init__(self, domain='c', text=None, name=None,
-                 decl_name=None, ttype=None, args=None, meta=None, nest=0):
+                 decl_name=None, ttype=None, args=None,
+                 quals=None, meta=None, nest=0):
         self._text = text
         self._name = name
         self._decl_name = decl_name
         self._ttype = ttype
         self._args = args
+        self._quals = quals
         self._meta = meta
         self._nest = nest
         self._domain = domain
@@ -104,10 +106,15 @@ class Docstring():
         name = self._get_decl_name()
         domain = self._domain
         ttype = self._ttype
+        quals = self._quals
 
-        spacer = ''
+        type_spacer = ''
         if ttype and not (len(ttype) == 0 or ttype.endswith('*')):
-            spacer = ' '
+            type_spacer = ' '
+
+        quals_spacer = ''
+        if quals and len(quals) > 0:
+            quals_spacer = ' '
 
         args = ''
         if self._args and len(self._args) > 0:
@@ -115,7 +122,8 @@ class Docstring():
             args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
         header = self._fmt.format(domain=domain, name=name, ttype=ttype,
-                                  type_spacer=spacer, args=args)
+                                  type_spacer=type_spacer, args=args,
+                                  quals=quals, quals_spacer=quals_spacer)
 
         return header.splitlines()
 
@@ -239,4 +247,4 @@ class MacroFunctionDocstring(Docstring):
 
 class FunctionDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. {domain}:function:: {ttype}{type_spacer}{name}({args})\n\n'
+    _fmt = '\n.. {domain}:function:: {ttype}{type_spacer}{name}({args}){quals_spacer}{quals}\n\n'

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -249,3 +249,7 @@ class MacroFunctionDocstring(Docstring):
 class FunctionDocstring(Docstring):
     _indent = 1
     _fmt = '\n.. {domain}:function:: {ttype}{type_spacer}{name}({args}){quals_spacer}{quals}\n\n'
+
+class ClassDocstring(_CompoundDocstring):
+    _indent = 1
+    _fmt = '\n.. cpp:class:: {name}\n\n'

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -253,3 +253,7 @@ class FunctionDocstring(Docstring):
 class ClassDocstring(_CompoundDocstring):
     _indent = 1
     _fmt = '\n.. cpp:class:: {name}\n\n'
+
+class EnumClassDocstring(Docstring):
+    _indent = 1
+    _fmt = '\n.. cpp:enum-class:: {name}\n\n'

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -118,7 +118,8 @@ class Docstring():
 
         args = ''
         if self._args and len(self._args) > 0:
-            arg_fmt = lambda t, n: f"{t}{'' if len(t) == 0 or t.endswith('*') else ' '}{n}"
+            pad_type = lambda t: '' if len(t) == 0 or t.endswith('*') or t.endswith('&') else ' '
+            arg_fmt = lambda t, n: f"{t}{pad_type(t)}{n}"
             args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
         header = self._fmt.format(domain=domain, name=name, ttype=ttype,

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -420,7 +420,8 @@ def _recursive_parse(domain, comments, errors, cursor, nest):
 
         ds = docstring.FunctionDocstring(domain=domain, text=text,
                                          nest=nest, name=name,
-                                         ttype=ttype, args=args, meta=meta)
+                                         ttype=ttype, args=args,
+                                         quals='', meta=meta)
         return [ds]
 
     # If we reach here, nothing matched i.e. there's a documentation comment

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -154,6 +154,8 @@ def _comment_extract(tu):
         # between the comment and the actual cursor being documented.
         if token_cursor.kind in [CursorKind.INVALID_FILE,
                                  CursorKind.TYPE_REF,
+                                 CursorKind.TEMPLATE_REF,
+                                 CursorKind.NAMESPACE_REF,
                                  CursorKind.PREPROCESSING_DIRECTIVE,
                                  CursorKind.MACRO_INSTANTIATION]:
             continue

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -288,7 +288,7 @@ def _type_fixup(cursor):
             break
 
     if cursor_type.kind == TypeKind.FUNCTIONPROTO:
-        pad = lambda s: s if s.endswith('*') else s + ' '
+        pad = lambda s: s if s.endswith('*') or s.endswith('&') else s + ' '
 
         args = []
         for c in cursor.get_children():

--- a/test/cpp-autoclass-no-members.rst
+++ b/test/cpp-autoclass-no-members.rst
@@ -1,0 +1,5 @@
+
+.. cpp:class:: foo
+
+   Classy foo.
+

--- a/test/cpp-autoclass-no-members.yaml
+++ b/test/cpp-autoclass-no-members.yaml
@@ -1,0 +1,7 @@
+domain: cpp
+directive: autoclass
+directive-arguments:
+  - foo
+directive-options:
+  file: cpp-class.cpp
+expected: cpp-autoclass-no-members.rst

--- a/test/cpp-autoclass.rst
+++ b/test/cpp-autoclass.rst
@@ -1,0 +1,20 @@
+
+.. cpp:class:: foo
+
+   Classy foo.
+
+
+   .. cpp:member:: mutable int mutable_member
+
+      A mutable member.
+
+
+   .. cpp:function:: private virtual void virtual_method(void)
+
+      A virtual method.
+
+
+   .. cpp:function:: protected const int *const_method_to_const(void) const
+
+      A const method to const.
+

--- a/test/cpp-autoclass.yaml
+++ b/test/cpp-autoclass.yaml
@@ -1,0 +1,11 @@
+domain: cpp
+directive: autoclass
+directive-arguments:
+  - foo
+directive-options:
+  file: cpp-class.cpp
+  members:
+    - mutable_member
+    - virtual_method
+    - const_method_to_const
+expected: cpp-autoclass.rst

--- a/test/cpp-class.cpp
+++ b/test/cpp-class.cpp
@@ -1,0 +1,101 @@
+/**
+ * Classy foo.
+ */
+class foo {
+	/** :cpp:class:`foo` constructor. */
+	foo();
+
+	/** :cpp:class:`foo` destructor. */
+	~foo();
+
+public:
+	/** The simplest member. */
+	int simplest;
+
+	/** A static member. */
+	static int static_member;
+
+	/** A const member. */
+	const int const_member;
+
+	/** A volatile member. */
+	volatile int volatile_member;
+
+	/** A static const member. */
+	static const int static_const_member;
+
+	/** A static constexpr member. */
+	static constexpr int static_constexpr_member = 0;
+
+	/** A mutable member. */
+	mutable int mutable_member;
+
+	/** A simple method. */
+	void simple_method(void);
+
+	/** A constexpr method. */
+	constexpr void constexpr_method(void);
+
+	/** A static method. */
+	static void static_method(void);
+
+private:
+	/** A virtual method. */
+	virtual void virtual_method(void);
+
+	/** A pure virtual method. */
+	virtual void pure_method(void) = 0;
+
+	/** A pure const virtual method. */
+	virtual void pure_const_method(void) const = 0;
+
+protected:
+	/** A const method. */
+	void const_method(void) const;
+
+	/** A method to const. */
+	const int *method_to_const(void);
+
+	/** A const method to const. */
+	const int *const_method_to_const(void) const;
+};
+
+/** A bar, classy by nature and association. Also implicitly private. */
+class bar: foo {
+};
+
+/** A public bar. */
+class public_bar: public foo {
+	/** A deleted method. */
+	void simple_method(void) = delete;
+
+	/** An overridden method. */
+	void pure_method(void) override;
+};
+
+/** A private bar. */
+class private_bar: private foo {
+};
+
+/** A protected bar. */
+class protected_bar: protected foo {
+};
+
+/** An eclectic bar. */
+class ecletic_bar: public public_bar, private private_bar, protected protected_bar {
+};
+
+/** And now for something... */
+class completely_different {
+	/** Something completely different. */
+	completely_different() = default;
+
+	/** Operator overload. */
+	completely_different operator+ (const completely_different &a);
+};
+
+/** Anonymous class. */
+class {
+	/** Member. */
+	int foo;
+} C;

--- a/test/cpp-class.rst
+++ b/test/cpp-class.rst
@@ -1,0 +1,155 @@
+
+.. cpp:class:: foo
+
+   Classy foo.
+
+
+   .. cpp:function:: foo(void)
+
+      :cpp:class:`foo` constructor.
+
+
+   .. cpp:function:: ~foo(void)
+
+      :cpp:class:`foo` destructor.
+
+
+   .. cpp:member:: int simplest
+
+      The simplest member.
+
+
+   .. cpp:var:: static int static_member
+
+      A static member.
+
+
+   .. cpp:member:: const int const_member
+
+      A const member.
+
+
+   .. cpp:member:: volatile int volatile_member
+
+      A volatile member.
+
+
+   .. cpp:var:: static const int static_const_member
+
+      A static const member.
+
+
+   .. cpp:var:: static constexpr int static_constexpr_member
+
+      A static constexpr member.
+
+
+   .. cpp:member:: mutable int mutable_member
+
+      A mutable member.
+
+
+   .. cpp:function:: public void simple_method(void)
+
+      A simple method.
+
+
+   .. cpp:function:: public constexpr void constexpr_method(void)
+
+      A constexpr method.
+
+
+   .. cpp:function:: public static void static_method(void)
+
+      A static method.
+
+
+   .. cpp:function:: private virtual void virtual_method(void)
+
+      A virtual method.
+
+
+   .. cpp:function:: private virtual void pure_method(void) = 0
+
+      A pure virtual method.
+
+
+   .. cpp:function:: private virtual void pure_const_method(void) const = 0
+
+      A pure const virtual method.
+
+
+   .. cpp:function:: protected void const_method(void) const
+
+      A const method.
+
+
+   .. cpp:function:: protected const int *method_to_const(void)
+
+      A method to const.
+
+
+   .. cpp:function:: protected const int *const_method_to_const(void) const
+
+      A const method to const.
+
+
+.. cpp:class:: bar: private foo
+
+   A bar, classy by nature and association. Also implicitly private.
+
+
+.. cpp:class:: public_bar: public foo
+
+   A public bar.
+
+
+   .. cpp:function:: private void simple_method(void) = delete
+
+      A deleted method.
+
+
+   .. cpp:function:: private virtual void pure_method(void) override
+
+      An overridden method.
+
+
+.. cpp:class:: private_bar: private foo
+
+   A private bar.
+
+
+.. cpp:class:: protected_bar: protected foo
+
+   A protected bar.
+
+
+.. cpp:class:: ecletic_bar: public public_bar, private private_bar, protected protected_bar
+
+   An eclectic bar.
+
+
+.. cpp:class:: completely_different
+
+   And now for something...
+
+
+   .. cpp:function:: completely_different(void) = default
+
+      Something completely different.
+
+
+   .. cpp:function:: private completely_different operator+(const completely_different &a)
+
+      Operator overload.
+
+
+.. cpp:class:: @anonymous_8f3f3775b6f196ec9d9cdbdbd61fc9b3
+
+   Anonymous class.
+
+
+   .. cpp:member:: int foo
+
+      Member.
+

--- a/test/cpp-class.yaml
+++ b/test/cpp-class.yaml
@@ -1,0 +1,5 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-class.cpp
+expected: cpp-class.rst

--- a/test/cpp-enum-class.cpp
+++ b/test/cpp-enum-class.cpp
@@ -1,0 +1,34 @@
+#include <type_traits>
+
+/** Enum class. */
+enum class breakfast {
+	/** Spam. */
+	spam,
+
+	/** More spam. */
+	more_spam,
+
+	/** Eggs. */
+	eggs,
+
+	/** Also spam. */
+	also_spam,
+};
+
+/**
+ * Enum struct is the same as enum class and it's all the same for referencing
+ * too. See: :cpp:enum:`breakfast` and :cpp:enum:`lunch`.
+ */
+enum struct lunch: long {
+	/** Much spam. */
+	much_spam,
+
+	/** No eggs. */
+	no_eggs,
+};
+
+/** I chose a theme and I'm sticking to it. */
+enum class dinner : std::underlying_type< lunch>::type {
+	/** Only spam. */
+	only_spam,
+};

--- a/test/cpp-enum-class.rst
+++ b/test/cpp-enum-class.rst
@@ -1,0 +1,51 @@
+
+.. cpp:enum-class:: breakfast
+
+   Enum class.
+
+
+   .. cpp:enumerator:: spam
+
+      Spam.
+
+
+   .. cpp:enumerator:: more_spam
+
+      More spam.
+
+
+   .. cpp:enumerator:: eggs
+
+      Eggs.
+
+
+   .. cpp:enumerator:: also_spam
+
+      Also spam.
+
+
+.. cpp:enum-class:: lunch: long
+
+   Enum struct is the same as enum class and it's all the same for referencing
+   too. See: :cpp:enum:`breakfast` and :cpp:enum:`lunch`.
+
+
+   .. cpp:enumerator:: much_spam
+
+      Much spam.
+
+
+   .. cpp:enumerator:: no_eggs
+
+      No eggs.
+
+
+.. cpp:enum-class:: dinner: std::underlying_type<lunch>::type
+
+   I chose a theme and I'm sticking to it.
+
+
+   .. cpp:enumerator:: only_spam
+
+      Only spam.
+

--- a/test/cpp-enum-class.yaml
+++ b/test/cpp-enum-class.yaml
@@ -1,0 +1,5 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-enum-class.cpp
+expected: cpp-enum-class.rst

--- a/test/cpp-function.rst
+++ b/test/cpp-function.rst
@@ -1,5 +1,5 @@
 
-.. cpp:function:: int foo(int bar, int baz)
+.. cpp:function:: static inline int foo(int bar, int baz)
 
    Foo function.
 

--- a/test/cpp-struct-class.cpp
+++ b/test/cpp-struct-class.cpp
@@ -1,0 +1,60 @@
+/** C++ structures are classes with different default access specifiers. */
+struct all_is_class {
+	/** Struct constructor. */
+	all_is_class();
+
+	/** Struct destructor. */
+	~all_is_class();
+
+public:
+	/** The simplest member. */
+	int simplest;
+
+	/** A static member. */
+	static int static_member;
+
+	/** A const member. */
+	const int const_member;
+
+	/** A volatile member. */
+	volatile int volatile_member;
+
+	/** A static const member. */
+	static const int static_const_member;
+
+	/** A static constexpr member. */
+	static constexpr int static_constexpr_member = 0;
+
+	/** A simple method. */
+	void simple_method(void);
+
+	/** Another simple method. */
+	void simple_method_2(void);
+
+	/** A static method. */
+	static void static_method(void);
+
+private:
+	/** A virtual method. */
+	virtual void virtual_method(void);
+
+	/** A pure virtual method. */
+	virtual void pure_method(void) = 0;
+
+	/** A pure const virtual method. */
+	virtual void pure_const_method(void) const = 0;
+
+protected:
+	/** A const method. */
+	void const_method(void) const;
+
+	/** A method to const. */
+	const int *method_to_const(void);
+
+	/** A const method to const. */
+	const int *const_method_to_const(void) const;
+};
+
+/** C++ structures are classes with different default access specifiers. */
+struct just_in_case: all_is_class {
+};

--- a/test/cpp-struct-class.rst
+++ b/test/cpp-struct-class.rst
@@ -1,0 +1,95 @@
+
+.. cpp:struct:: all_is_class
+
+   C++ structures are classes with different default access specifiers.
+
+
+   .. cpp:function:: all_is_class(void)
+
+      Struct constructor.
+
+
+   .. cpp:function:: ~all_is_class(void)
+
+      Struct destructor.
+
+
+   .. cpp:member:: int simplest
+
+      The simplest member.
+
+
+   .. cpp:var:: static int static_member
+
+      A static member.
+
+
+   .. cpp:member:: const int const_member
+
+      A const member.
+
+
+   .. cpp:member:: volatile int volatile_member
+
+      A volatile member.
+
+
+   .. cpp:var:: static const int static_const_member
+
+      A static const member.
+
+
+   .. cpp:var:: static constexpr int static_constexpr_member
+
+      A static constexpr member.
+
+
+   .. cpp:function:: public void simple_method(void)
+
+      A simple method.
+
+
+   .. cpp:function:: public void simple_method_2(void)
+
+      Another simple method.
+
+
+   .. cpp:function:: public static void static_method(void)
+
+      A static method.
+
+
+   .. cpp:function:: private virtual void virtual_method(void)
+
+      A virtual method.
+
+
+   .. cpp:function:: private virtual void pure_method(void) = 0
+
+      A pure virtual method.
+
+
+   .. cpp:function:: private virtual void pure_const_method(void) const = 0
+
+      A pure const virtual method.
+
+
+   .. cpp:function:: protected void const_method(void) const
+
+      A const method.
+
+
+   .. cpp:function:: protected const int *method_to_const(void)
+
+      A method to const.
+
+
+   .. cpp:function:: protected const int *const_method_to_const(void) const
+
+      A const method to const.
+
+
+.. cpp:struct:: just_in_case: public all_is_class
+
+   C++ structures are classes with different default access specifiers.
+

--- a/test/cpp-struct-class.yaml
+++ b/test/cpp-struct-class.yaml
@@ -1,0 +1,5 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-struct-class.cpp
+expected: cpp-struct-class.rst

--- a/test/cpp-template.cpp
+++ b/test/cpp-template.cpp
@@ -1,0 +1,51 @@
+#include <vector>
+
+/** Templated class. */
+template <typename T, class C, char V>
+class foo: C {
+	/** M for Member. */
+	T member;
+
+	/** V for Variable. */
+	char variable = V;
+};
+
+/** Variadic templates, why not? */
+template<auto...>
+class variadic_foo;
+
+/** A different kind of variadic template. */
+template<typename T, typename... Ts>
+void variadic_fooer(T foo, Ts ... bar);
+
+/** White space shenanigans. */
+template < typename T ,typename ...Ts>
+void space_fuzer(T foo,Ts ... bar);
+
+/**
+ * Templated templated class. Puny compilers / standards don't allow further
+ * recursion.
+ */
+template<template<typename T, class C, char V> class who>
+class inception_foo {
+
+	/** Fully defined templated type. */
+	std::vector<int> nothing_much;
+
+	/** Who as in 'who thought this was a good idea?' */
+	who<int, std::vector<char>, 'z'> whoever;
+
+	/**
+	 * Templated method within a template.
+	 *
+	 * :param y: Yes, this works too.
+	 */
+	template<typename Z, typename Y> Z templated_method(Y y);
+};
+
+/**
+ * `typename` and `class` are interchangeable, but we respect the source code
+ * just in case.
+ */
+template<template<class T, typename C, char V> typename who>
+class alt_inception_foo;

--- a/test/cpp-template.rst
+++ b/test/cpp-template.rst
@@ -1,0 +1,59 @@
+
+.. cpp:class:: template<typename T, class C, char V> foo: private C
+
+   Templated class.
+
+
+   .. cpp:member:: T member
+
+      M for Member.
+
+
+   .. cpp:member:: char variable
+
+      V for Variable.
+
+
+.. cpp:class:: template<auto...> variadic_foo
+
+   Variadic templates, why not?
+
+
+.. cpp:function:: template<typename T, typename... Ts> void variadic_fooer(T foo, Ts... bar)
+
+   A different kind of variadic template.
+
+
+.. cpp:function:: template<typename T, typename... Ts> void space_fuzer(T foo, Ts... bar)
+
+   White space shenanigans.
+
+
+.. cpp:class:: template<template<typename T, class C, char V> class who> inception_foo
+
+   Templated templated class. Puny compilers / standards don't allow further
+   recursion.
+
+
+   .. cpp:member:: std::vector<int> nothing_much
+
+      Fully defined templated type.
+
+
+   .. cpp:member:: who<int, std::vector<char>, 'z'> whoever
+
+      Who as in 'who thought this was a good idea?'
+
+
+   .. cpp:function:: private template<typename Z, typename Y> Z templated_method(Y y)
+
+      Templated method within a template.
+
+      :param y: Yes, this works too.
+
+
+.. cpp:class:: template<template<class T, typename C, char V> typename who> alt_inception_foo
+
+   `typename` and `class` are interchangeable, but we respect the source code
+   just in case.
+

--- a/test/cpp-template.yaml
+++ b/test/cpp-template.yaml
@@ -1,0 +1,8 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-template.cpp
+directive-options:
+  clang:
+    - --std=c++17
+expected: cpp-template.rst

--- a/test/cpp-variable.rst
+++ b/test/cpp-variable.rst
@@ -1,5 +1,5 @@
 
-.. cpp:var:: int sheesh
+.. cpp:var:: static int sheesh
 
    This is a variable document.
 
@@ -54,7 +54,7 @@
    Array of pointers.
 
 
-.. cpp:var:: int multi_dim[1][2]
+.. cpp:var:: extern int multi_dim[1][2]
 
    Multi-dimensional array.
 

--- a/test/example-variable.rst
+++ b/test/example-variable.rst
@@ -4,7 +4,7 @@
    The name says it all.
 
 
-.. c:var:: struct list *entries
+.. c:var:: static struct list *entries
 
    The list of entries.
 

--- a/test/function.c
+++ b/test/function.c
@@ -1,12 +1,12 @@
 /**
  * Foo function.
  */
-int foo(int bar, int baz);
+static inline int foo(int bar, int baz);
 
 /**
  * No parameters.
  */
-int no_parameters(void);
+extern int no_parameters(void);
 
 /**
  * Empty parameter list.

--- a/test/function.rst
+++ b/test/function.rst
@@ -1,5 +1,5 @@
 
-.. c:function:: int foo(int bar, int baz)
+.. c:function:: static inline int foo(int bar, int baz)
 
    Foo function.
 

--- a/test/variable.c
+++ b/test/variable.c
@@ -72,4 +72,4 @@ char *array_of_pointers[1];
 /**
  * Multi-dimensional array.
  */
-int multi_dim[1][2];
+extern int multi_dim[1][2];

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -1,5 +1,5 @@
 
-.. c:var:: int sheesh
+.. c:var:: static int sheesh
 
    This is a variable document.
 
@@ -54,7 +54,7 @@
    Array of pointers.
 
 
-.. c:var:: int multi_dim[1][2]
+.. c:var:: extern int multi_dim[1][2]
 
    Multi-dimensional array.
 


### PR DESCRIPTION
So this is a big one feature wise, but I think it turned out quite neat for all it does.

The bottom line: this adds support for classes and class like structs and enums; templates; and even improves on extraction of qualifiers and weird specifiers that I think are relevant enough API wise (constexpr, mutable, override... the works). I'm honestly unaware of any single current C++ feature that is not covered within this scope. Hope I'm not wrong.

The one (only?) conspicuous absence here is namespace traversal and tracking. Granted that's a huge one which basically renders all of this pretty much useless, but still nice. Also, I wouldn't dare try to solve namespaces in this series.

Implementation wise, some of these things required me to drop to the token level, which is never ideal, but I tried to do so sparingly and only for relevant cursors to keep the performance hit to a minimum. There are a few places where small legibility improvements can be had perhaps if we loose some consistency in the helper functions' return values (returning None or '') and some function / variable names took a while to pick and I'm still unsure I picked the right ones.

Greatest pet peeve of mine right now is found early in the series with the addition of a `quals` argument to `Docstring`. These are meant for very specific qualifiers, but without changing too much in docstring (and perhaps the parser), I don't see an easy way around something like that. Maybe we can name it `method_quals` instead, but it's a mouthful and doesn't help that much. My best idea so far, but I would prefer to explore that separately, would be a `kwargs` approach to docstring and offload more of the formatting to individual specializations of docstring or other common bases for them instead of trying to cram so many different things into a single rigid API.

No attempt was given at updating the docs.