### PR TITLE
C++ types v2

### DIFF
--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -273,6 +273,10 @@ class CppAutoEnumDirective(_AutoCompoundDirective):
     _domain = 'cpp'
     _docstring_types = [docstring.EnumDocstring]
 
+class CppAutoClassDirective(_AutoCompoundDirective):
+    _domain = 'cpp'
+    _docstring_types = [docstring.ClassDocstring]
+
 def _deprecate(conf, old, new, default=None):
     if conf[old]:
         logger = logging.getLogger(__name__)
@@ -317,6 +321,7 @@ def setup(app):
     app.add_directive_to_domain('cpp', 'autoenum', CppAutoEnumDirective)
     app.add_directive_to_domain('cpp', 'automacro', CppAutoMacroDirective)
     app.add_directive_to_domain('cpp', 'autofunction', CppAutoFunctionDirective)
+    app.add_directive_to_domain('cpp', 'autoclass', CppAutoClassDirective)
 
     return dict(version=__version__,
                 parallel_read_safe=True, parallel_write_safe=True)

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-2021 Jani Nikula <jani@nikula.org>
-# Copyright (c) 2018-2022 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
+# Copyright (c) 2018-2023 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 """
 Documentation comment storage and converter
@@ -51,12 +51,14 @@ class Docstring():
     _fmt = ''
 
     def __init__(self, domain='c', text=None, name=None,
-                 decl_name=None, ttype=None, args=None, meta=None, nest=0):
+                 decl_name=None, ttype=None, args=None,
+                 quals=None, meta=None, nest=0):
         self._text = text
         self._name = name
         self._decl_name = decl_name
         self._ttype = ttype
         self._args = args
+        self._quals = quals
         self._meta = meta
         self._nest = nest
         self._domain = domain
@@ -104,10 +106,15 @@ class Docstring():
         name = self._get_decl_name()
         domain = self._domain
         ttype = self._ttype
+        quals = self._quals
 
-        spacer = ''
+        type_spacer = ''
         if ttype and not (len(ttype) == 0 or ttype.endswith('*')):
-            spacer = ' '
+            type_spacer = ' '
+
+        quals_spacer = ''
+        if quals and len(quals) > 0:
+            quals_spacer = ' '
 
         args = ''
         if self._args and len(self._args) > 0:
@@ -115,7 +122,8 @@ class Docstring():
             args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
         header = self._fmt.format(domain=domain, name=name, ttype=ttype,
-                                  type_spacer=spacer, args=args)
+                                  type_spacer=type_spacer, args=args,
+                                  quals=quals, quals_spacer=quals_spacer)
 
         return header.splitlines()
 
@@ -239,4 +247,4 @@ class MacroFunctionDocstring(Docstring):
 
 class FunctionDocstring(Docstring):
     _indent = 1
-    _fmt = '\n.. {domain}:function:: {ttype}{type_spacer}{name}({args})\n\n'
+    _fmt = '\n.. {domain}:function:: {ttype}{type_spacer}{name}({args}){quals_spacer}{quals}\n\n'

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -249,3 +249,7 @@ class MacroFunctionDocstring(Docstring):
 class FunctionDocstring(Docstring):
     _indent = 1
     _fmt = '\n.. {domain}:function:: {ttype}{type_spacer}{name}({args}){quals_spacer}{quals}\n\n'
+
+class ClassDocstring(_CompoundDocstring):
+    _indent = 1
+    _fmt = '\n.. cpp:class:: {name}\n\n'

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -253,3 +253,7 @@ class FunctionDocstring(Docstring):
 class ClassDocstring(_CompoundDocstring):
     _indent = 1
     _fmt = '\n.. cpp:class:: {name}\n\n'
+
+class EnumClassDocstring(Docstring):
+    _indent = 1
+    _fmt = '\n.. cpp:enum-class:: {name}\n\n'

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -118,7 +118,8 @@ class Docstring():
 
         args = ''
         if self._args and len(self._args) > 0:
-            arg_fmt = lambda t, n: f"{t}{'' if len(t) == 0 or t.endswith('*') else ' '}{n}"
+            pad_type = lambda t: '' if len(t) == 0 or t.endswith('*') or t.endswith('&') else ' '
+            arg_fmt = lambda t, n: f"{t}{pad_type(t)}{n}"
             args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
         header = self._fmt.format(domain=domain, name=name, ttype=ttype,

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -287,7 +287,7 @@ def _var_type_fixup(cursor):
             break
 
     if cursor_type.kind == TypeKind.FUNCTIONPROTO:
-        pad = lambda s: s if s.endswith('*') else s + ' '
+        pad = lambda s: s if s.endswith('*') or s.endswith('&') else s + ' '
 
         args = []
         for c in cursor.get_children():

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -427,7 +427,8 @@ def _recursive_parse(domain, comments, errors, cursor, nest):
         ttype, args = _function_fixup(cursor)
         ds = docstring.FunctionDocstring(domain=domain, text=text,
                                          nest=nest, name=name,
-                                         ttype=ttype, args=args, meta=meta)
+                                         ttype=ttype, args=args,
+                                         quals='', meta=meta)
         return [ds]
 
     # If we reach here, nothing matched i.e. there's a documentation comment

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -154,6 +154,8 @@ def _comment_extract(tu):
         # between the comment and the actual cursor being documented.
         if token_cursor.kind in [CursorKind.INVALID_FILE,
                                  CursorKind.TYPE_REF,
+                                 CursorKind.TEMPLATE_REF,
+                                 CursorKind.NAMESPACE_REF,
                                  CursorKind.PREPROCESSING_DIRECTIVE,
                                  CursorKind.MACRO_INSTANTIATION]:
             continue

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -249,8 +249,8 @@ def _get_function_quals(cursor):
 
     return quals
 
-def _type_fixup(cursor):
-    """Fix non trivial types' spelling and append qualifiers.
+def _var_type_fixup(cursor):
+    """Fix non trivial variable and argument types.
 
     If this is an array, the dimensions should be applied to the name, not
     the type.
@@ -290,7 +290,7 @@ def _type_fixup(cursor):
         args = []
         for c in cursor.get_children():
             if c.kind == CursorKind.PARM_DECL:
-                arg_ttype, arg_name = _type_fixup(c)
+                arg_ttype, arg_name = _var_type_fixup(c)
                 args.append(f'{pad(arg_ttype)}{arg_name}' if arg_name else arg_ttype)
         if cursor_type.is_function_variadic():
             args.append('...')
@@ -326,7 +326,7 @@ def _get_args(cursor):
     if cursor.type.kind == TypeKind.FUNCTIONPROTO:
         for c in cursor.get_children():
             if c.kind == CursorKind.PARM_DECL:
-                arg_ttype, arg_name = _type_fixup(c)
+                arg_ttype, arg_name = _var_type_fixup(c)
                 args.extend([(arg_ttype, arg_name)])
 
         if cursor.type.is_function_variadic():
@@ -370,7 +370,7 @@ def _recursive_parse(domain, comments, errors, cursor, nest):
 
     elif cursor.kind in [CursorKind.VAR_DECL, CursorKind.FIELD_DECL]:
         # Note: Preserve original name
-        ttype, decl_name = _type_fixup(cursor)
+        ttype, decl_name = _var_type_fixup(cursor)
 
         if cursor.kind == CursorKind.VAR_DECL:
             ds = docstring.VarDocstring(domain=domain, text=text, nest=nest,

--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -304,6 +304,57 @@ def _get_access_specifier(cursor, domain='cpp'):
 
     return name_map.get(cursor.access_specifier, None)
 
+def _get_template_line(cursor):
+    """Get the template arguments of a cursor.
+
+    This recurses for templated template arguments.
+
+    Returns:
+        String with the form 'template<...> ' if the cursor is a template or
+        `None` otherwise. When the cursor represents a templated template
+        argument, the returned string is actually of the form 'template<...>
+        name', but this should only occur under recursion.
+    """
+    # We only add the name when we recurse, in which case we need to track the
+    # name of the templated template argument. Otherwise the name is not part of
+    # the template arguments.
+    name = ''
+
+    if cursor.kind not in [CursorKind.CLASS_TEMPLATE,
+                           CursorKind.FUNCTION_TEMPLATE,
+                           CursorKind.TEMPLATE_TEMPLATE_PARAMETER]:
+        return None
+
+    # The type of type parameters can be 'typename' and 'class'. These are
+    # equivalent, but we want it to look like the source code for consistency.
+    # We can do it by looking at the tokens directly. This is slightly
+    # complicated due to variadic template type parameters.
+    def typetype(cursor):
+        tokens = list(cursor.get_tokens())
+        if tokens[-2].spelling == '...':
+            return f'{tokens[-3].spelling}...'
+        else:
+            return f'{tokens[-2].spelling}'
+
+    # We need to add the keyword 'typename' or 'class' if we have recursed and
+    # therefore we are inside the template argument list.
+    if cursor.kind == CursorKind.TEMPLATE_TEMPLATE_PARAMETER:
+        name = f' {typetype(cursor)} {cursor.spelling}'
+
+    template_args = []
+    for child in cursor.get_children():
+        if child.kind == CursorKind.TEMPLATE_TYPE_PARAMETER:
+            template_args.append(f'{typetype(child)} {child.spelling}')
+        elif child.kind == CursorKind.TEMPLATE_NON_TYPE_PARAMETER:
+            arg_name = f' {child.spelling}' if child.spelling != '' else '...'
+            template_args.append(f'{child.type.spelling}{arg_name}')
+        elif child.kind == CursorKind.TEMPLATE_TEMPLATE_PARAMETER:
+            arg = _get_template_line(child)
+            if arg:
+                template_args.append(arg)
+
+    return f'template<{", ".join(template_args)}>{name}'
+
 def _specifiers_fixup(cursor, basetype):
     """Fix the type for C++ specifiers.
 
@@ -441,7 +492,10 @@ def _type_definition_fixup(cursor):
         if scopedenum_type:
             colon_suffix = scopedenum_type
 
-    return f'{cursor.spelling}{colon_suffix}'
+    template = _get_template_line(cursor)
+    template = template + ' ' if template else ''
+
+    return f'{template}{cursor.spelling}{colon_suffix}'
 
 def _get_args(cursor, domain):
     """Get function / method arguments."""
@@ -466,6 +520,11 @@ def _function_fixup(cursor, domain):
     args = _get_args(cursor, domain)
 
     full_type = _get_function_quals(cursor)
+
+    template_line = _get_template_line(cursor)
+    if template_line:
+        full_type.append(template_line)
+
     full_type.append(cursor.result_type.spelling)
 
     ttype = ' '.join(full_type)
@@ -485,6 +544,10 @@ def _method_fixup(cursor):
     pre_quals, pos_quals = _get_method_quals(cursor)
 
     full_type.extend(pre_quals)
+
+    template_line = _get_template_line(cursor)
+    if template_line:
+        full_type.append(template_line)
 
     if cursor.kind not in [CursorKind.CONSTRUCTOR, CursorKind.DESTRUCTOR]:
         full_type.append(cursor.result_type.spelling)

--- a/test/cpp-autoclass-no-members.rst
+++ b/test/cpp-autoclass-no-members.rst
@@ -1,0 +1,5 @@
+
+.. cpp:class:: foo
+
+   Classy foo.
+

--- a/test/cpp-autoclass-no-members.yaml
+++ b/test/cpp-autoclass-no-members.yaml
@@ -1,0 +1,7 @@
+domain: cpp
+directive: autoclass
+directive-arguments:
+  - foo
+directive-options:
+  file: cpp-class.cpp
+expected: cpp-autoclass-no-members.rst

--- a/test/cpp-autoclass.rst
+++ b/test/cpp-autoclass.rst
@@ -1,0 +1,20 @@
+
+.. cpp:class:: foo
+
+   Classy foo.
+
+
+   .. cpp:member:: mutable int mutable_member
+
+      A mutable member.
+
+
+   .. cpp:function:: private virtual void virtual_method(void)
+
+      A virtual method.
+
+
+   .. cpp:function:: protected const int *const_method_to_const(void) const
+
+      A const method to const.
+

--- a/test/cpp-autoclass.yaml
+++ b/test/cpp-autoclass.yaml
@@ -1,0 +1,11 @@
+domain: cpp
+directive: autoclass
+directive-arguments:
+  - foo
+directive-options:
+  file: cpp-class.cpp
+  members:
+    - mutable_member
+    - virtual_method
+    - const_method_to_const
+expected: cpp-autoclass.rst

--- a/test/cpp-class.cpp
+++ b/test/cpp-class.cpp
@@ -1,0 +1,101 @@
+/**
+ * Classy foo.
+ */
+class foo {
+public:
+	/** :cpp:class:`foo` constructor. */
+	foo();
+
+	/** :cpp:class:`foo` destructor. */
+	~foo();
+
+	/** The simplest member. */
+	int simplest;
+
+	/** A static member. */
+	static int static_member;
+
+	/** A const member. */
+	const int const_member;
+
+	/** A volatile member. */
+	volatile int volatile_member;
+
+	/** A static const member. */
+	static const int static_const_member;
+
+	/** A static constexpr member. */
+	static constexpr int static_constexpr_member = 0;
+
+	/** A mutable member. */
+	mutable int mutable_member;
+
+	/** A simple method. */
+	void simple_method(void);
+
+	/** A constexpr method. */
+	constexpr void constexpr_method(void);
+
+	/** A static method. */
+	static void static_method(void);
+
+private:
+	/** A virtual method. */
+	virtual void virtual_method(void);
+
+	/** A pure virtual method. */
+	virtual void pure_method(void) = 0;
+
+	/** A pure const virtual method. */
+	virtual void pure_const_method(void) const = 0;
+
+protected:
+	/** A const method. */
+	void const_method(void) const;
+
+	/** A method to const. */
+	const int *method_to_const(void);
+
+	/** A const method to const. */
+	const int *const_method_to_const(void) const;
+};
+
+/** A bar, classy by nature and association. Also implicitly private. */
+class bar: foo {
+};
+
+/** A public bar. */
+class public_bar: public foo {
+	/** A deleted method. */
+	void simple_method(void) = delete;
+
+	/** An overridden method. */
+	void pure_method(void) override;
+};
+
+/** A private bar. */
+class private_bar: private foo {
+};
+
+/** A protected bar. */
+class protected_bar: protected foo {
+};
+
+/** An eclectic bar. */
+class ecletic_bar: public public_bar, private private_bar, protected protected_bar {
+};
+
+/** And now for something... */
+class completely_different {
+	/** Something completely different. */
+	completely_different() = default;
+
+	/** Operator overload. */
+	completely_different operator+ (const completely_different &a);
+};
+
+/** Anonymous class. */
+class {
+	/** Member. */
+	int foo;
+} C;

--- a/test/cpp-class.rst
+++ b/test/cpp-class.rst
@@ -1,0 +1,155 @@
+
+.. cpp:class:: foo
+
+   Classy foo.
+
+
+   .. cpp:function:: public foo(void)
+
+      :cpp:class:`foo` constructor.
+
+
+   .. cpp:function:: public ~foo(void)
+
+      :cpp:class:`foo` destructor.
+
+
+   .. cpp:member:: public int simplest
+
+      The simplest member.
+
+
+   .. cpp:var:: public static int static_member
+
+      A static member.
+
+
+   .. cpp:member:: public const int const_member
+
+      A const member.
+
+
+   .. cpp:member:: public volatile int volatile_member
+
+      A volatile member.
+
+
+   .. cpp:var:: public static const int static_const_member
+
+      A static const member.
+
+
+   .. cpp:var:: public static constexpr int static_constexpr_member
+
+      A static constexpr member.
+
+
+   .. cpp:member:: public mutable int mutable_member
+
+      A mutable member.
+
+
+   .. cpp:function:: public void simple_method(void)
+
+      A simple method.
+
+
+   .. cpp:function:: public constexpr void constexpr_method(void)
+
+      A constexpr method.
+
+
+   .. cpp:function:: public static void static_method(void)
+
+      A static method.
+
+
+   .. cpp:function:: private virtual void virtual_method(void)
+
+      A virtual method.
+
+
+   .. cpp:function:: private virtual void pure_method(void) = 0
+
+      A pure virtual method.
+
+
+   .. cpp:function:: private virtual void pure_const_method(void) const = 0
+
+      A pure const virtual method.
+
+
+   .. cpp:function:: protected void const_method(void) const
+
+      A const method.
+
+
+   .. cpp:function:: protected const int *method_to_const(void)
+
+      A method to const.
+
+
+   .. cpp:function:: protected const int *const_method_to_const(void) const
+
+      A const method to const.
+
+
+.. cpp:class:: bar: private foo
+
+   A bar, classy by nature and association. Also implicitly private.
+
+
+.. cpp:class:: public_bar: public foo
+
+   A public bar.
+
+
+   .. cpp:function:: private void simple_method(void) = delete
+
+      A deleted method.
+
+
+   .. cpp:function:: private virtual void pure_method(void) override
+
+      An overridden method.
+
+
+.. cpp:class:: private_bar: private foo
+
+   A private bar.
+
+
+.. cpp:class:: protected_bar: protected foo
+
+   A protected bar.
+
+
+.. cpp:class:: ecletic_bar: public public_bar, private private_bar, protected protected_bar
+
+   An eclectic bar.
+
+
+.. cpp:class:: completely_different
+
+   And now for something...
+
+
+   .. cpp:function:: private completely_different(void) = default
+
+      Something completely different.
+
+
+   .. cpp:function:: private completely_different operator+(const completely_different &a)
+
+      Operator overload.
+
+
+.. cpp:class:: @anonymous_8f3f3775b6f196ec9d9cdbdbd61fc9b3
+
+   Anonymous class.
+
+
+   .. cpp:member:: private int foo
+
+      Member.
+

--- a/test/cpp-class.yaml
+++ b/test/cpp-class.yaml
@@ -1,0 +1,5 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-class.cpp
+expected: cpp-class.rst

--- a/test/cpp-enum-class.cpp
+++ b/test/cpp-enum-class.cpp
@@ -1,0 +1,34 @@
+#include <type_traits>
+
+/** Enum class. */
+enum class breakfast {
+	/** Spam. */
+	spam,
+
+	/** More spam. */
+	more_spam,
+
+	/** Eggs. */
+	eggs,
+
+	/** Also spam. */
+	also_spam,
+};
+
+/**
+ * Enum struct is the same as enum class and it's all the same for referencing
+ * too. See: :cpp:enum:`breakfast` and :cpp:enum:`lunch`.
+ */
+enum struct lunch: long {
+	/** Much spam. */
+	much_spam,
+
+	/** No eggs. */
+	no_eggs,
+};
+
+/** I chose a theme and I'm sticking to it. */
+enum class dinner : std::underlying_type< lunch>::type {
+	/** Only spam. */
+	only_spam,
+};

--- a/test/cpp-enum-class.rst
+++ b/test/cpp-enum-class.rst
@@ -1,0 +1,51 @@
+
+.. cpp:enum-class:: breakfast
+
+   Enum class.
+
+
+   .. cpp:enumerator:: spam
+
+      Spam.
+
+
+   .. cpp:enumerator:: more_spam
+
+      More spam.
+
+
+   .. cpp:enumerator:: eggs
+
+      Eggs.
+
+
+   .. cpp:enumerator:: also_spam
+
+      Also spam.
+
+
+.. cpp:enum-class:: lunch: long
+
+   Enum struct is the same as enum class and it's all the same for referencing
+   too. See: :cpp:enum:`breakfast` and :cpp:enum:`lunch`.
+
+
+   .. cpp:enumerator:: much_spam
+
+      Much spam.
+
+
+   .. cpp:enumerator:: no_eggs
+
+      No eggs.
+
+
+.. cpp:enum-class:: dinner: std::underlying_type<lunch>::type
+
+   I chose a theme and I'm sticking to it.
+
+
+   .. cpp:enumerator:: only_spam
+
+      Only spam.
+

--- a/test/cpp-enum-class.yaml
+++ b/test/cpp-enum-class.yaml
@@ -1,0 +1,5 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-enum-class.cpp
+expected: cpp-enum-class.rst

--- a/test/cpp-function.rst
+++ b/test/cpp-function.rst
@@ -1,5 +1,5 @@
 
-.. cpp:function:: int foo(int bar, int baz)
+.. cpp:function:: static inline int foo(int bar, int baz)
 
    Foo function.
 

--- a/test/cpp-struct-class.cpp
+++ b/test/cpp-struct-class.cpp
@@ -1,0 +1,60 @@
+/** C++ structures are classes with different default access specifiers. */
+struct all_is_class {
+	/** Struct constructor. */
+	all_is_class();
+
+	/** Struct destructor. */
+	~all_is_class();
+
+public:
+	/** The simplest member. */
+	int simplest;
+
+	/** A static member. */
+	static int static_member;
+
+	/** A const member. */
+	const int const_member;
+
+	/** A volatile member. */
+	volatile int volatile_member;
+
+	/** A static const member. */
+	static const int static_const_member;
+
+	/** A static constexpr member. */
+	static constexpr int static_constexpr_member = 0;
+
+	/** A simple method. */
+	void simple_method(void);
+
+	/** Another simple method. */
+	void simple_method_2(void);
+
+	/** A static method. */
+	static void static_method(void);
+
+private:
+	/** A virtual method. */
+	virtual void virtual_method(void);
+
+	/** A pure virtual method. */
+	virtual void pure_method(void) = 0;
+
+	/** A pure const virtual method. */
+	virtual void pure_const_method(void) const = 0;
+
+protected:
+	/** A const method. */
+	void const_method(void) const;
+
+	/** A method to const. */
+	const int *method_to_const(void);
+
+	/** A const method to const. */
+	const int *const_method_to_const(void) const;
+};
+
+/** C++ structures are classes with different default access specifiers. */
+struct just_in_case: all_is_class {
+};

--- a/test/cpp-struct-class.rst
+++ b/test/cpp-struct-class.rst
@@ -1,0 +1,95 @@
+
+.. cpp:struct:: all_is_class
+
+   C++ structures are classes with different default access specifiers.
+
+
+   .. cpp:function:: public all_is_class(void)
+
+      Struct constructor.
+
+
+   .. cpp:function:: public ~all_is_class(void)
+
+      Struct destructor.
+
+
+   .. cpp:member:: public int simplest
+
+      The simplest member.
+
+
+   .. cpp:var:: public static int static_member
+
+      A static member.
+
+
+   .. cpp:member:: public const int const_member
+
+      A const member.
+
+
+   .. cpp:member:: public volatile int volatile_member
+
+      A volatile member.
+
+
+   .. cpp:var:: public static const int static_const_member
+
+      A static const member.
+
+
+   .. cpp:var:: public static constexpr int static_constexpr_member
+
+      A static constexpr member.
+
+
+   .. cpp:function:: public void simple_method(void)
+
+      A simple method.
+
+
+   .. cpp:function:: public void simple_method_2(void)
+
+      Another simple method.
+
+
+   .. cpp:function:: public static void static_method(void)
+
+      A static method.
+
+
+   .. cpp:function:: private virtual void virtual_method(void)
+
+      A virtual method.
+
+
+   .. cpp:function:: private virtual void pure_method(void) = 0
+
+      A pure virtual method.
+
+
+   .. cpp:function:: private virtual void pure_const_method(void) const = 0
+
+      A pure const virtual method.
+
+
+   .. cpp:function:: protected void const_method(void) const
+
+      A const method.
+
+
+   .. cpp:function:: protected const int *method_to_const(void)
+
+      A method to const.
+
+
+   .. cpp:function:: protected const int *const_method_to_const(void) const
+
+      A const method to const.
+
+
+.. cpp:struct:: just_in_case: public all_is_class
+
+   C++ structures are classes with different default access specifiers.
+

--- a/test/cpp-struct-class.yaml
+++ b/test/cpp-struct-class.yaml
@@ -1,0 +1,5 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-struct-class.cpp
+expected: cpp-struct-class.rst

--- a/test/cpp-struct.rst
+++ b/test/cpp-struct.rst
@@ -6,27 +6,27 @@
    Woohoo.
 
 
-   .. cpp:member:: int jesh
+   .. cpp:member:: public int jesh
 
       member
 
 
-   .. cpp:member:: int array_member[5]
+   .. cpp:member:: public int array_member[5]
 
       array member
 
 
-   .. cpp:member:: void *pointer_member
+   .. cpp:member:: public void *pointer_member
 
       pointer member
 
 
-   .. cpp:member:: int (*function_pointer_member)(int, int)
+   .. cpp:member:: public int (*function_pointer_member)(int, int)
 
       function pointer member with parameter names omitted
 
 
-   .. cpp:member:: int (*other_function_pointer_member)(int foo, int bar)
+   .. cpp:member:: public int (*other_function_pointer_member)(int foo, int bar)
 
       function pointer member with parameter names
 
@@ -34,7 +34,7 @@
       :param bar: the bar
 
 
-   .. cpp:member:: struct sample_struct *next
+   .. cpp:member:: public struct sample_struct *next
 
       foo next
 
@@ -44,7 +44,7 @@
    Anonymous struct documentation.
 
 
-   .. cpp:member:: int foo
+   .. cpp:member:: public int foo
 
       Struct member.
 
@@ -59,7 +59,7 @@
       Anonymous sub-struct.
 
 
-      .. cpp:member:: int foo_member
+      .. cpp:member:: public int foo_member
 
          Member foo.
 

--- a/test/cpp-template.cpp
+++ b/test/cpp-template.cpp
@@ -1,0 +1,51 @@
+#include <vector>
+
+/** Templated class. */
+template <typename T, class C, char V>
+class foo: C {
+	/** M for Member. */
+	T member;
+
+	/** V for Variable. */
+	char variable = V;
+};
+
+/** Variadic templates, why not? */
+template<auto...>
+class variadic_foo;
+
+/** A different kind of variadic template. */
+template<typename T, typename... Ts>
+void variadic_fooer(T foo, Ts ... bar);
+
+/** White space shenanigans. */
+template < typename T ,typename ...Ts>
+void space_fuzer(T foo,Ts ... bar);
+
+/**
+ * Templated templated class. Puny compilers / standards don't allow further
+ * recursion.
+ */
+template<template<typename T, class C, char V> class who>
+class inception_foo {
+
+	/** Fully defined templated type. */
+	std::vector<int> nothing_much;
+
+	/** Who as in 'who thought this was a good idea?' */
+	who<int, std::vector<char>, 'z'> whoever;
+
+	/**
+	 * Templated method within a template.
+	 *
+	 * :param y: Yes, this works too.
+	 */
+	template<typename Z, typename Y> Z templated_method(Y y);
+};
+
+/**
+ * `typename` and `class` are interchangeable, but we respect the source code
+ * just in case.
+ */
+template<template<class T, typename C, char V> typename who>
+class alt_inception_foo;

--- a/test/cpp-template.rst
+++ b/test/cpp-template.rst
@@ -1,0 +1,59 @@
+
+.. cpp:class:: template<typename T, class C, char V> foo: private C
+
+   Templated class.
+
+
+   .. cpp:member:: private T member
+
+      M for Member.
+
+
+   .. cpp:member:: private char variable
+
+      V for Variable.
+
+
+.. cpp:class:: template<auto...> variadic_foo
+
+   Variadic templates, why not?
+
+
+.. cpp:function:: template<typename T, typename... Ts> void variadic_fooer(T foo, Ts... bar)
+
+   A different kind of variadic template.
+
+
+.. cpp:function:: template<typename T, typename... Ts> void space_fuzer(T foo, Ts... bar)
+
+   White space shenanigans.
+
+
+.. cpp:class:: template<template<typename T, class C, char V> class who> inception_foo
+
+   Templated templated class. Puny compilers / standards don't allow further
+   recursion.
+
+
+   .. cpp:member:: private std::vector<int> nothing_much
+
+      Fully defined templated type.
+
+
+   .. cpp:member:: private who<int, std::vector<char>, 'z'> whoever
+
+      Who as in 'who thought this was a good idea?'
+
+
+   .. cpp:function:: private template<typename Z, typename Y> Z templated_method(Y y)
+
+      Templated method within a template.
+
+      :param y: Yes, this works too.
+
+
+.. cpp:class:: template<template<class T, typename C, char V> typename who> alt_inception_foo
+
+   `typename` and `class` are interchangeable, but we respect the source code
+   just in case.
+

--- a/test/cpp-template.yaml
+++ b/test/cpp-template.yaml
@@ -1,0 +1,8 @@
+domain: cpp
+directive: autodoc
+directive-arguments:
+  - cpp-template.cpp
+directive-options:
+  clang:
+    - --std=c++17
+expected: cpp-template.rst

--- a/test/cpp-typedef-struct.rst
+++ b/test/cpp-typedef-struct.rst
@@ -4,7 +4,7 @@
    named typedeffed struct
 
 
-   .. cpp:member:: int m
+   .. cpp:member:: public int m
 
       named member
 
@@ -14,7 +14,7 @@
    unnamed typedeffed struct
 
 
-   .. cpp:member:: int m
+   .. cpp:member:: public int m
 
       unnamed member
 

--- a/test/cpp-variable.rst
+++ b/test/cpp-variable.rst
@@ -1,5 +1,5 @@
 
-.. cpp:var:: int sheesh
+.. cpp:var:: static int sheesh
 
    This is a variable document.
 
@@ -54,7 +54,7 @@
    Array of pointers.
 
 
-.. cpp:var:: int multi_dim[1][2]
+.. cpp:var:: extern int multi_dim[1][2]
 
    Multi-dimensional array.
 

--- a/test/example-variable.rst
+++ b/test/example-variable.rst
@@ -4,7 +4,7 @@
    The name says it all.
 
 
-.. c:var:: struct list *entries
+.. c:var:: static struct list *entries
 
    The list of entries.
 

--- a/test/function.c
+++ b/test/function.c
@@ -1,12 +1,12 @@
 /**
  * Foo function.
  */
-int foo(int bar, int baz);
+static inline int foo(int bar, int baz);
 
 /**
  * No parameters.
  */
-int no_parameters(void);
+extern int no_parameters(void);
 
 /**
  * Empty parameter list.

--- a/test/function.rst
+++ b/test/function.rst
@@ -1,5 +1,5 @@
 
-.. c:function:: int foo(int bar, int baz)
+.. c:function:: static inline int foo(int bar, int baz)
 
    Foo function.
 

--- a/test/variable.c
+++ b/test/variable.c
@@ -72,4 +72,4 @@ char *array_of_pointers[1];
 /**
  * Multi-dimensional array.
  */
-int multi_dim[1][2];
+extern int multi_dim[1][2];

--- a/test/variable.rst
+++ b/test/variable.rst
@@ -1,5 +1,5 @@
 
-.. c:var:: int sheesh
+.. c:var:: static int sheesh
 
    This is a variable document.
 
@@ -54,7 +54,7 @@
    Array of pointers.
 
 
-.. c:var:: int multi_dim[1][2]
+.. c:var:: extern int multi_dim[1][2]
 
    Multi-dimensional array.
 


### PR DESCRIPTION
This supersedes #120.

Other than the proposed changes, I noticed and fixed some small issues:
1. Constructors / destructors were not getting an access specifier. Somehow it fell
through the cracks before, but it's now fixed and reflected in the test cases.
2. Member variables were not getting an access specifier. This was a big one, can't
imagine how I missed it, but it was even more flagrant than the c/dtors. Fixed
now. This is by far the biggest difference and is pretty much limited to the commit [parser: improve support for C++ specifiers](https://github.com/jnikula/hawkmoth/commit/d7f7005c51e85a6febfca043f76c6e7a1a4c80c1)
3. A few code paths were simplified. Partly due to the now clearer type fixup
thingy which made the improvements obvious.
4. Some mutually exclusive branches were improved for marginally better
performance: if one, avoid the other.
