### PR TITLE
test: add test coverage and reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 *~
+.coverage
 .venv
 build
 dist
 hawkmoth.egg-info
+test/coverage-report

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flake8
 pytest
+pytest-cov
 pytest-xdist
 sphinx
 sphinx-testing

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ packages =
 dev =
     flake8
     pytest
+    pytest-cov
     pytest-xdist
     sphinx-testing
     strictyaml

--- a/test/Makefile.local
+++ b/test/Makefile.local
@@ -17,3 +17,12 @@ test-examples:
 
 quick-test:
 	pytest -n auto -m "not full" $(test_dir)
+
+test-coverage:
+	pytest -n auto --cov=hawkmoth --cov-report=term $(test_dir)
+
+test-coverage-html:
+	pytest -n auto --cov=hawkmoth --cov-report=term --cov-report=html:$(test_dir)/coverage-report $(test_dir)
+	@echo "Coverage report: file://$(CURDIR)/$(test_dir)/coverage-report/index.html"
+
+CLEAN := $(CLEAN) .coverage $(test_dir)/coverage-report


### PR DESCRIPTION
@BrunoMSantos I wondered about the coverage of the tests, in particular the new C++ stuff, as well as what parts actually get executed of the all the things in parser.py.

I've looked at your #122 with this, and it's pretty good. Just run `make test-coverage-html` and browse the results.
