### PR TITLE
Testcase class

### DIFF
--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -30,7 +30,7 @@ def _get_output(testcase, app, status, warning, output_suffix, **options):
     return testenv.read_file(output_filename), None
 
 def _get_expected(testcase, app, status, warning, output_suffix, **options):
-    shutil.copyfile(testenv.get_expected_filename(testcase),
+    shutil.copyfile(testcase.get_expected_filename(),
                     os.path.join(app.srcdir, 'index.rst'))
 
     # Hack: It's not possible to disable search via configuration

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -10,7 +10,7 @@ from sphinx_testing import with_app
 
 from test import testenv
 
-def _get_output(testcase, app, status, warning, output_suffix, **options):
+def _get_output(testcase, app, status, warning, output_suffix):
     input_filename = testcase.get_input_filename()
     shutil.copyfile(input_filename,
                     os.path.join(app.srcdir, os.path.basename(input_filename)))
@@ -29,7 +29,7 @@ def _get_output(testcase, app, status, warning, output_suffix, **options):
 
     return testenv.read_file(output_filename), None
 
-def _get_expected(testcase, app, status, warning, output_suffix, **options):
+def _get_expected(testcase, app, status, warning, output_suffix):
     shutil.copyfile(testcase.get_expected_filename(),
                     os.path.join(app.srcdir, 'index.rst'))
 
@@ -44,12 +44,12 @@ def _get_expected(testcase, app, status, warning, output_suffix, **options):
 
 # Test using Sphinx plain text builder
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
-def _get_output_text(testcase, app, status, warning, **options):
-    return _get_output(testcase, app, status, warning, 'txt', **options)
+def _get_output_text(testcase, app, status, warning, **unused):
+    return _get_output(testcase, app, status, warning, 'txt')
 
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
-def _get_expected_text(testcase, app, status, warning, **options):
-    return _get_expected(testcase, app, status, warning, 'txt', **options)
+def _get_expected_text(testcase, app, status, warning, **unused):
+    return _get_expected(testcase, app, status, warning, 'txt')
 
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
                          ids=testenv.get_testid)
@@ -58,12 +58,12 @@ def test_directive_text(testcase):
 
 # Test using Sphinx html builder
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
-def _get_output_html(testcase, app, status, warning, **options):
-    return _get_output(testcase, app, status, warning, 'html', **options)
+def _get_output_html(testcase, app, status, warning, **unused):
+    return _get_output(testcase, app, status, warning, 'html')
 
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
-def _get_expected_html(testcase, app, status, warning, **options):
-    return _get_expected(testcase, app, status, warning, 'html', **options)
+def _get_expected_html(testcase, app, status, warning, **unused):
+    return _get_expected(testcase, app, status, warning, 'html')
 
 @pytest.mark.full
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -15,7 +15,7 @@ def _get_output(testcase, app, status, warning, output_suffix, **options):
     shutil.copyfile(input_filename,
                     os.path.join(app.srcdir, os.path.basename(input_filename)))
 
-    directive_str = testenv.get_directive_string(options)
+    directive_str = testcase.get_directive_string()
 
     with open(os.path.join(app.srcdir, 'index.rst'), 'w') as f:
         f.write(directive_str)

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -10,7 +10,10 @@ from sphinx_testing import with_app
 
 from test import testenv
 
-def _get_output(testcase, app, status, warning, output_suffix):
+def _get_suffix(buildername):
+    return 'txt' if buildername == 'text' else buildername
+
+def _get_output(testcase, app, status, warning):
     input_filename = testcase.get_input_filename()
     shutil.copyfile(input_filename,
                     os.path.join(app.srcdir, os.path.basename(input_filename)))
@@ -25,11 +28,12 @@ def _get_output(testcase, app, status, warning, output_suffix):
 
     app.build()
 
+    output_suffix = _get_suffix(app.builder.name)
     output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
 
     return testenv.read_file(output_filename), None
 
-def _get_expected(testcase, app, status, warning, output_suffix):
+def _get_expected(testcase, app, status, warning):
     shutil.copyfile(testcase.get_expected_filename(),
                     os.path.join(app.srcdir, 'index.rst'))
 
@@ -38,6 +42,7 @@ def _get_expected(testcase, app, status, warning, output_suffix):
 
     app.build()
 
+    output_suffix = _get_suffix(app.builder.name)
     output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
 
     return testenv.read_file(output_filename), None
@@ -59,11 +64,11 @@ def _get_html_testcases(path):
 # Test using Sphinx plain text builder
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
 def _get_output_text(testcase, app, status, warning, **unused):
-    return _get_output(testcase, app, status, warning, 'txt')
+    return _get_output(testcase, app, status, warning)
 
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
 def _get_expected_text(testcase, app, status, warning, **unused):
-    return _get_expected(testcase, app, status, warning, 'txt')
+    return _get_expected(testcase, app, status, warning)
 
 @pytest.mark.parametrize('testcase', _get_text_testcases(testenv.testdir),
                          ids=testenv.get_testid)
@@ -73,11 +78,11 @@ def test_directive_text(testcase):
 # Test using Sphinx html builder
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
 def _get_output_html(testcase, app, status, warning, **unused):
-    return _get_output(testcase, app, status, warning, 'html')
+    return _get_output(testcase, app, status, warning)
 
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
 def _get_expected_html(testcase, app, status, warning, **unused):
-    return _get_expected(testcase, app, status, warning, 'html')
+    return _get_expected(testcase, app, status, warning)
 
 @pytest.mark.full
 @pytest.mark.parametrize('testcase', _get_html_testcases(testenv.testdir),

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -11,7 +11,7 @@ from sphinx_testing import with_app
 from test import testenv
 
 def _get_output(testcase, app, status, warning, output_suffix, **options):
-    input_filename = testenv.get_input_filename(testcase)
+    input_filename = testcase.get_input_filename()
     shutil.copyfile(input_filename,
                     os.path.join(app.srcdir, os.path.basename(input_filename)))
 

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -50,21 +50,21 @@ def _get_expected(testcase, app, status, warning):
 # Test using Sphinx plain text builder
 class ExtensionTextTestcase(testenv.Testcase):
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
-    def get_output(self, app, status, warning, **unused):
+    def get_output(self, app, status, warning):
         return _get_output(self, app, status, warning)
 
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
-    def get_expected(self, app, status, warning, **unused):
+    def get_expected(self, app, status, warning):
         return _get_expected(self, app, status, warning)
 
 # Test using Sphinx html builder
 class ExtensionHtmlTestcase(testenv.Testcase):
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
-    def get_output(self, app, status, warning, **unused):
+    def get_output(self, app, status, warning):
         return _get_output(self, app, status, warning)
 
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
-    def get_expected(self, app, status, warning, **unused):
+    def get_expected(self, app, status, warning):
         return _get_expected(self, app, status, warning)
 
 def _get_text_testcases(path):

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -13,59 +13,60 @@ from test import testenv
 def _get_suffix(buildername):
     return 'txt' if buildername == 'text' else buildername
 
-def _get_output(testcase, app, status, warning):
-    input_filename = testcase.get_input_filename()
-    shutil.copyfile(input_filename,
-                    os.path.join(app.srcdir, os.path.basename(input_filename)))
+class ExtensionTestcase(testenv.Testcase):
+    def get_output(self, app, status, warning):
+        input_filename = self.get_input_filename()
+        shutil.copyfile(input_filename,
+                        os.path.join(app.srcdir, os.path.basename(input_filename)))
 
-    directive_str = testcase.get_directive_string()
+        directive_str = self.get_directive_string()
 
-    with open(os.path.join(app.srcdir, 'index.rst'), 'w') as f:
-        f.write(directive_str)
+        with open(os.path.join(app.srcdir, 'index.rst'), 'w') as f:
+            f.write(directive_str)
 
-    # Hack: It's not possible to disable search via configuration
-    app.builder.search = False
+        # Hack: It's not possible to disable search via configuration
+        app.builder.search = False
 
-    app.build()
+        app.build()
 
-    output_suffix = _get_suffix(app.builder.name)
-    output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
+        output_suffix = _get_suffix(app.builder.name)
+        output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
 
-    return testenv.read_file(output_filename), None
+        return testenv.read_file(output_filename), None
 
-def _get_expected(testcase, app, status, warning):
-    shutil.copyfile(testcase.get_expected_filename(),
-                    os.path.join(app.srcdir, 'index.rst'))
+    def get_expected(self, app, status, warning):
+        shutil.copyfile(self.get_expected_filename(),
+                        os.path.join(app.srcdir, 'index.rst'))
 
-    # Hack: It's not possible to disable search via configuration
-    app.builder.search = False
+        # Hack: It's not possible to disable search via configuration
+        app.builder.search = False
 
-    app.build()
+        app.build()
 
-    output_suffix = _get_suffix(app.builder.name)
-    output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
+        output_suffix = _get_suffix(app.builder.name)
+        output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
 
-    return testenv.read_file(output_filename), None
+        return testenv.read_file(output_filename), None
 
 # Test using Sphinx plain text builder
-class ExtensionTextTestcase(testenv.Testcase):
+class ExtensionTextTestcase(ExtensionTestcase):
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
     def get_output(self, app, status, warning):
-        return _get_output(self, app, status, warning)
+        return super().get_output(app, status, warning)
 
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
     def get_expected(self, app, status, warning):
-        return _get_expected(self, app, status, warning)
+        return super().get_expected(app, status, warning)
 
 # Test using Sphinx html builder
-class ExtensionHtmlTestcase(testenv.Testcase):
+class ExtensionHtmlTestcase(ExtensionTestcase):
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
     def get_output(self, app, status, warning):
-        return _get_output(self, app, status, warning)
+        return super().get_output(app, status, warning)
 
     @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
     def get_expected(self, app, status, warning):
-        return _get_expected(self, app, status, warning)
+        return super().get_expected(app, status, warning)
 
 def _get_text_testcases(path):
     for f in testenv.get_testcase_filenames(path):

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -54,7 +54,7 @@ def _get_expected_text(testcase, app, status, warning, **unused):
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_directive_text(testcase):
-    testenv.run_test(testcase, _get_output_text, _get_expected_text)
+    testcase.run_test(_get_output_text, _get_expected_text)
 
 # Test using Sphinx html builder
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
@@ -69,4 +69,4 @@ def _get_expected_html(testcase, app, status, warning, **unused):
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_directive_html(testcase):
-    testenv.run_test(testcase, _get_output_html, _get_expected_html)
+    testcase.run_test(_get_output_html, _get_expected_html)

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -47,11 +47,25 @@ def _get_expected(testcase, app, status, warning):
 
     return testenv.read_file(output_filename), None
 
+# Test using Sphinx plain text builder
 class ExtensionTextTestcase(testenv.Testcase):
-    pass
+    @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
+    def get_output(self, app, status, warning, **unused):
+        return _get_output(self, app, status, warning)
 
+    @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
+    def get_expected(self, app, status, warning, **unused):
+        return _get_expected(self, app, status, warning)
+
+# Test using Sphinx html builder
 class ExtensionHtmlTestcase(testenv.Testcase):
-    pass
+    @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
+    def get_output(self, app, status, warning, **unused):
+        return _get_output(self, app, status, warning)
+
+    @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
+    def get_expected(self, app, status, warning, **unused):
+        return _get_expected(self, app, status, warning)
 
 def _get_text_testcases(path):
     for f in testenv.get_testcase_filenames(path):
@@ -61,31 +75,13 @@ def _get_html_testcases(path):
     for f in testenv.get_testcase_filenames(path):
         yield ExtensionHtmlTestcase(f)
 
-# Test using Sphinx plain text builder
-@with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
-def _get_output_text(testcase, app, status, warning, **unused):
-    return _get_output(testcase, app, status, warning)
-
-@with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
-def _get_expected_text(testcase, app, status, warning, **unused):
-    return _get_expected(testcase, app, status, warning)
-
 @pytest.mark.parametrize('testcase', _get_text_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_directive_text(testcase):
-    testcase.run_test(_get_output_text, _get_expected_text)
-
-# Test using Sphinx html builder
-@with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
-def _get_output_html(testcase, app, status, warning, **unused):
-    return _get_output(testcase, app, status, warning)
-
-@with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='html')
-def _get_expected_html(testcase, app, status, warning, **unused):
-    return _get_expected(testcase, app, status, warning)
+    testcase.run_test()
 
 @pytest.mark.full
 @pytest.mark.parametrize('testcase', _get_html_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_directive_html(testcase):
-    testcase.run_test(_get_output_html, _get_expected_html)
+    testcase.run_test()

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -42,6 +42,20 @@ def _get_expected(testcase, app, status, warning, output_suffix):
 
     return testenv.read_file(output_filename), None
 
+class ExtensionTextTestcase(testenv.Testcase):
+    pass
+
+class ExtensionHtmlTestcase(testenv.Testcase):
+    pass
+
+def _get_text_testcases(path):
+    for f in testenv.get_testcase_filenames(path):
+        yield ExtensionTextTestcase(f)
+
+def _get_html_testcases(path):
+    for f in testenv.get_testcase_filenames(path):
+        yield ExtensionHtmlTestcase(f)
+
 # Test using Sphinx plain text builder
 @with_app(confdir=testenv.testdir, create_new_srcdir=True, buildername='text')
 def _get_output_text(testcase, app, status, warning, **unused):
@@ -51,7 +65,7 @@ def _get_output_text(testcase, app, status, warning, **unused):
 def _get_expected_text(testcase, app, status, warning, **unused):
     return _get_expected(testcase, app, status, warning, 'txt')
 
-@pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
+@pytest.mark.parametrize('testcase', _get_text_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_directive_text(testcase):
     testcase.run_test(_get_output_text, _get_expected_text)
@@ -66,7 +80,7 @@ def _get_expected_html(testcase, app, status, warning, **unused):
     return _get_expected(testcase, app, status, warning, 'html')
 
 @pytest.mark.full
-@pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
+@pytest.mark.parametrize('testcase', _get_html_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_directive_html(testcase):
     testcase.run_test(_get_output_html, _get_expected_html)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -71,7 +71,7 @@ def _get_output(testcase, monkeypatch, capsys, **options):
     return docs_str, errors_str
 
 def _get_expected(testcase, monkeypatch, **options):
-    return testenv.read_file(testenv.get_expected_filename(testcase)), \
+    return testenv.read_file(testcase.get_expected_filename()), \
         testenv.read_file(testenv.get_stderr_filename(testcase))
 
 @pytest.mark.full

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -40,7 +40,9 @@ def _capture(capsys):
 
     return captured.out, _stderr_basename(captured.err)
 
-def _get_output(testcase, monkeypatch, capsys, **options):
+def _get_output(testcase, monkeypatch, capsys, **unused):
+    options = testcase.options
+
     args = [testcase.get_input_filename()]
 
     directive = options.get('directive')
@@ -70,7 +72,7 @@ def _get_output(testcase, monkeypatch, capsys, **options):
 
     return docs_str, errors_str
 
-def _get_expected(testcase, monkeypatch, **options):
+def _get_expected(testcase, monkeypatch, **unused):
     return testenv.read_file(testcase.get_expected_filename()), \
         testenv.read_file(testcase.get_stderr_filename())
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -72,7 +72,7 @@ def _get_output(testcase, monkeypatch, capsys, **options):
 
 def _get_expected(testcase, monkeypatch, **options):
     return testenv.read_file(testcase.get_expected_filename()), \
-        testenv.read_file(testenv.get_stderr_filename(testcase))
+        testenv.read_file(testcase.get_stderr_filename())
 
 @pytest.mark.full
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -40,6 +40,9 @@ def _capture(capsys):
 
     return captured.out, _stderr_basename(captured.err)
 
+class CliTestcase(testenv.Testcase):
+    pass
+
 def _get_output(testcase, monkeypatch, capsys, **unused):
     options = testcase.options
 
@@ -76,8 +79,12 @@ def _get_expected(testcase, monkeypatch, **unused):
     return testenv.read_file(testcase.get_expected_filename()), \
         testenv.read_file(testcase.get_stderr_filename())
 
+def _get_cli_testcases(path):
+    for f in testenv.get_testcase_filenames(path):
+        yield CliTestcase(f)
+
 @pytest.mark.full
-@pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
+@pytest.mark.parametrize('testcase', _get_cli_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_cli(testcase, monkeypatch, capsys):
     monkeypatch.setattr('sys.argv', ['dummy'])

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -81,4 +81,4 @@ def _get_expected(testcase, monkeypatch, **unused):
                          ids=testenv.get_testid)
 def test_cli(testcase, monkeypatch, capsys):
     monkeypatch.setattr('sys.argv', ['dummy'])
-    testenv.run_test(testcase, _get_output, _get_expected, monkeypatch, capsys)
+    testcase.run_test(_get_output, _get_expected, monkeypatch, capsys)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -41,7 +41,7 @@ def _capture(capsys):
     return captured.out, _stderr_basename(captured.err)
 
 def _get_output(testcase, monkeypatch, capsys, **options):
-    args = [testenv.get_input_filename(testcase)]
+    args = [testcase.get_input_filename()]
 
     directive = options.get('directive')
     if directive != 'autodoc':

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -15,7 +15,9 @@ def _transform(transform, lines):
         text = transform(text)
         lines[:] = [line for line in text.splitlines()]
 
-def _get_output(testcase, **options):
+def _get_output(testcase, **unused):
+    options = testcase.options
+
     docs_str = ''
     errors_str = ''
 
@@ -52,7 +54,7 @@ def _get_output(testcase, **options):
 
     return docs_str, errors_str
 
-def _get_expected(testcase, **options):
+def _get_expected(testcase, **unused):
     return testenv.read_file(testcase.get_expected_filename()), \
         testenv.read_file(testcase.get_stderr_filename())
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -61,4 +61,4 @@ def _get_expected(testcase, **unused):
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_parser(testcase):
-    testenv.run_test(testcase, _get_output, _get_expected)
+    testcase.run_test(_get_output, _get_expected)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -15,6 +15,9 @@ def _transform(transform, lines):
         text = transform(text)
         lines[:] = [line for line in text.splitlines()]
 
+class ParserTestcase(testenv.Testcase):
+    pass
+
 def _get_output(testcase, **unused):
     options = testcase.options
 
@@ -58,7 +61,11 @@ def _get_expected(testcase, **unused):
     return testenv.read_file(testcase.get_expected_filename()), \
         testenv.read_file(testcase.get_stderr_filename())
 
-@pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
+def _get_parser_testcases(path):
+    for f in testenv.get_testcase_filenames(path):
+        yield ParserTestcase(f)
+
+@pytest.mark.parametrize('testcase', _get_parser_testcases(testenv.testdir),
                          ids=testenv.get_testid)
 def test_parser(testcase):
     testcase.run_test(_get_output, _get_expected)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -30,7 +30,7 @@ def _get_output(testcase, **options):
     if directive != 'autodoc':
         pytest.skip(f'{directive} directive test')
 
-    input_filename = testenv.get_input_filename(testcase)
+    input_filename = testcase.get_input_filename()
 
     options = options.get('directive-options', {})
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -53,7 +53,7 @@ def _get_output(testcase, **options):
     return docs_str, errors_str
 
 def _get_expected(testcase, **options):
-    return testenv.read_file(testenv.get_expected_filename(testcase)), \
+    return testenv.read_file(testcase.get_expected_filename()), \
         testenv.read_file(testenv.get_stderr_filename(testcase))
 
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -54,7 +54,7 @@ def _get_output(testcase, **options):
 
 def _get_expected(testcase, **options):
     return testenv.read_file(testcase.get_expected_filename()), \
-        testenv.read_file(testenv.get_stderr_filename(testcase))
+        testenv.read_file(testcase.get_stderr_filename())
 
 @pytest.mark.parametrize('testcase', testenv.get_testcases(testenv.testdir),
                          ids=testenv.get_testid)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -16,7 +16,7 @@ def _transform(transform, lines):
         lines[:] = [line for line in text.splitlines()]
 
 class ParserTestcase(testenv.Testcase):
-    def get_output(self, **unused):
+    def get_output(self):
         options = self.options
 
         docs_str = ''
@@ -55,7 +55,7 @@ class ParserTestcase(testenv.Testcase):
 
         return docs_str, errors_str
 
-    def get_expected(self, **unused):
+    def get_expected(self):
         return testenv.read_file(self.get_expected_filename()), \
             testenv.read_file(self.get_stderr_filename())
 

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -88,14 +88,12 @@ class Testcase:
 
         return directive_str
 
-    def run_test(self, monkeypatch=None, capsys=None):
+    def run_test(self):
         if self.options.get('expected-failure'):
             pytest.xfail()
 
-        output_docs, output_errors = self.get_output(monkeypatch=monkeypatch,
-                                                     capsys=capsys)
-        expect_docs, expect_errors = self.get_expected(monkeypatch=monkeypatch,
-                                                       capsys=capsys)
+        output_docs, output_errors = self.get_output()
+        expect_docs, expect_errors = self.get_expected()
 
         assert output_docs == expect_docs
         assert output_errors == expect_errors

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -49,6 +49,19 @@ class Testcase:
 
         return os.path.join(os.path.dirname(self.filename), relative)
 
+    def get_input_filename(self):
+        options = self.options
+
+        directive = options.get('directive')
+        if directive == 'autodoc':
+            arguments = options.get('directive-arguments', [])
+            basename = arguments[0]
+        else:
+            directive_options = options.get('directive-options', {})
+            basename = directive_options.get('file')
+
+        return self.get_relative_filename(basename)
+
 def get_testid(testcase):
     return testcase.get_testid()
 
@@ -63,19 +76,6 @@ def get_testcase_filenames(path):
 def get_testcases(path):
     for f in get_testcase_filenames(path):
         yield Testcase(f)
-
-def get_input_filename(testcase):
-    options = get_testcase_options(testcase)
-
-    directive = options.get('directive')
-    if directive == 'autodoc':
-        arguments = options.get('directive-arguments', [])
-        basename = arguments[0]
-    else:
-        directive_options = options.get('directive-options', {})
-        basename = directive_options.get('file')
-
-    return testcase.get_relative_filename(basename)
 
 def get_expected_filename(testcase):
     options = get_testcase_options(testcase)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -88,14 +88,14 @@ class Testcase:
 
         return directive_str
 
-    def run_test(self, get_output, get_expected, monkeypatch=None, capsys=None):
+    def run_test(self, monkeypatch=None, capsys=None):
         if self.options.get('expected-failure'):
             pytest.xfail()
 
-        output_docs, output_errors = get_output(self, monkeypatch=monkeypatch,
-                                                capsys=capsys)
-        expect_docs, expect_errors = get_expected(self, monkeypatch=monkeypatch,
-                                                  capsys=capsys)
+        output_docs, output_errors = self.get_output(monkeypatch=monkeypatch,
+                                                     capsys=capsys)
+        expect_docs, expect_errors = self.get_expected(monkeypatch=monkeypatch,
+                                                       capsys=capsys)
 
         assert output_docs == expect_docs
         assert output_errors == expect_errors

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -65,6 +65,9 @@ class Testcase:
     def get_expected_filename(self):
         return self.get_relative_filename(self.options.get('expected'))
 
+    def get_stderr_filename(self):
+        return self.get_relative_filename(self.options.get('errors'))
+
 def get_testid(testcase):
     return testcase.get_testid()
 
@@ -79,11 +82,6 @@ def get_testcase_filenames(path):
 def get_testcases(path):
     for f in get_testcase_filenames(path):
         yield Testcase(f)
-
-def get_stderr_filename(testcase):
-    options = get_testcase_options(testcase)
-
-    return testcase.get_relative_filename(options.get('errors'))
 
 def get_directive_string(options):
     domain = options.get('domain', None)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -68,6 +68,26 @@ class Testcase:
     def get_stderr_filename(self):
         return self.get_relative_filename(self.options.get('errors'))
 
+    def get_directive_string(self):
+        options = self.options
+
+        domain = options.get('domain', None)
+        directive = options.get('directive')
+        arguments = options.get('directive-arguments', [])
+        arguments_str = ' '.join(arguments)
+
+        directive_str = f'.. {domain}:{directive}:: {arguments_str}\n'
+
+        directive_options = options.get('directive-options', {})
+
+        for key, value in directive_options.items():
+            if isinstance(value, list):
+                value = ', '.join(value)
+            space = ' ' if len(value) else ''
+            directive_str += f'   :{key}:{space}{value}\n'
+
+        return directive_str
+
 def get_testid(testcase):
     return testcase.get_testid()
 
@@ -82,24 +102,6 @@ def get_testcase_filenames(path):
 def get_testcases(path):
     for f in get_testcase_filenames(path):
         yield Testcase(f)
-
-def get_directive_string(options):
-    domain = options.get('domain', None)
-    directive = options.get('directive')
-    arguments = options.get('directive-arguments', [])
-    arguments_str = ' '.join(arguments)
-
-    directive_str = f'.. {domain}:{directive}:: {arguments_str}\n'
-
-    directive_options = options.get('directive-options', {})
-
-    for key, value in directive_options.items():
-        if isinstance(value, list):
-            value = ', '.join(value)
-        space = ' ' if len(value) else ''
-        directive_str += f'   :{key}:{space}{value}\n'
-
-    return directive_str
 
 def read_file(filename):
     if not filename or not os.path.isfile(filename):

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -62,6 +62,9 @@ class Testcase:
 
         return self.get_relative_filename(basename)
 
+    def get_expected_filename(self):
+        return self.get_relative_filename(self.options.get('expected'))
+
 def get_testid(testcase):
     return testcase.get_testid()
 
@@ -76,11 +79,6 @@ def get_testcase_filenames(path):
 def get_testcases(path):
     for f in get_testcase_filenames(path):
         yield Testcase(f)
-
-def get_expected_filename(testcase):
-    options = get_testcase_options(testcase)
-
-    return testcase.get_relative_filename(options.get('expected'))
 
 def get_stderr_filename(testcase):
     options = get_testcase_options(testcase)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -88,6 +88,18 @@ class Testcase:
 
         return directive_str
 
+    def run_test(self, get_output, get_expected, monkeypatch=None, capsys=None):
+        if self.options.get('expected-failure'):
+            pytest.xfail()
+
+        output_docs, output_errors = get_output(self, monkeypatch=monkeypatch,
+                                                capsys=capsys)
+        expect_docs, expect_errors = get_expected(self, monkeypatch=monkeypatch,
+                                                  capsys=capsys)
+
+        assert output_docs == expect_docs
+        assert output_errors == expect_errors
+
 def get_testid(testcase):
     return testcase.get_testid()
 
@@ -107,15 +119,3 @@ def read_file(filename):
 
     with open(filename, 'r') as f:
         return f.read()
-
-def run_test(testcase, get_output, get_expected, monkeypatch=None, capsys=None):
-    if testcase.options.get('expected-failure'):
-        pytest.xfail()
-
-    output_docs, output_errors = get_output(testcase, monkeypatch=monkeypatch,
-                                            capsys=capsys)
-    expect_docs, expect_errors = get_expected(testcase, monkeypatch=monkeypatch,
-                                              capsys=capsys)
-
-    assert output_docs == expect_docs
-    assert output_errors == expect_errors

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -43,6 +43,12 @@ class Testcase:
 
         return name
 
+    def get_relative_filename(self, relative):
+        if relative is None:
+            return None
+
+        return os.path.join(os.path.dirname(self.filename), relative)
+
 def get_testid(testcase):
     return testcase.get_testid()
 
@@ -58,12 +64,6 @@ def get_testcases(path):
     for f in get_testcase_filenames(path):
         yield Testcase(f)
 
-def get_testcase_relative_filename(testcase, relative):
-    if relative is None:
-        return None
-
-    return os.path.join(os.path.dirname(testcase.filename), relative)
-
 def get_input_filename(testcase):
     options = get_testcase_options(testcase)
 
@@ -75,17 +75,17 @@ def get_input_filename(testcase):
         directive_options = options.get('directive-options', {})
         basename = directive_options.get('file')
 
-    return get_testcase_relative_filename(testcase, basename)
+    return testcase.get_relative_filename(basename)
 
 def get_expected_filename(testcase):
     options = get_testcase_options(testcase)
 
-    return get_testcase_relative_filename(testcase, options.get('expected'))
+    return testcase.get_relative_filename(options.get('expected'))
 
 def get_stderr_filename(testcase):
     options = get_testcase_options(testcase)
 
-    return get_testcase_relative_filename(testcase, options.get('errors'))
+    return testcase.get_relative_filename(options.get('errors'))
 
 def get_directive_string(options):
     domain = options.get('domain', None)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -91,9 +91,6 @@ class Testcase:
 def get_testid(testcase):
     return testcase.get_testid()
 
-def get_testcase_options(testcase):
-    return testcase.options
-
 def get_testcase_filenames(path):
     for f in sorted(os.listdir(path)):
         if f.endswith(testext):
@@ -112,15 +109,13 @@ def read_file(filename):
         return f.read()
 
 def run_test(testcase, get_output, get_expected, monkeypatch=None, capsys=None):
-    options = get_testcase_options(testcase)
-
-    if options.get('expected-failure'):
+    if testcase.options.get('expected-failure'):
         pytest.xfail()
 
     output_docs, output_errors = get_output(testcase, monkeypatch=monkeypatch,
-                                            capsys=capsys, **options)
+                                            capsys=capsys)
     expect_docs, expect_errors = get_expected(testcase, monkeypatch=monkeypatch,
-                                              capsys=capsys, **options)
+                                              capsys=capsys)
 
     assert output_docs == expect_docs
     assert output_errors == expect_errors

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -15,14 +15,9 @@ sys.path.insert(0, rootdir)
 
 def get_testid(testcase):
     """Convert a testcase filename into a test case identifier."""
-    name = os.path.splitext(os.path.basename(testcase))[0]
+    name = os.path.splitext(os.path.basename(testcase.filename))[0]
 
     return name
-
-def get_testcases(path):
-    for f in sorted(os.listdir(path)):
-        if f.endswith(testext):
-            yield os.path.join(path, f)
 
 options_schema = strictyaml.Map({
     'domain': strictyaml.Enum(['c', 'cpp']),
@@ -42,20 +37,29 @@ options_schema = strictyaml.Map({
     'expected': strictyaml.Str(),
 })
 
-def get_testcase_options(testcase):
-    # options are optional
-    options = {}
-    if os.path.isfile(testcase):
-        with open(testcase, 'r') as f:
-            options = strictyaml.load(f.read(), options_schema).data
+class Testcase:
+    def __init__(self, filename):
+        self.filename = filename
+        with open(filename, 'r') as f:
+            self.options = strictyaml.load(f.read(), options_schema).data
 
-    return options
+def get_testcase_options(testcase):
+    return testcase.options
+
+def get_testcase_filenames(path):
+    for f in sorted(os.listdir(path)):
+        if f.endswith(testext):
+            yield os.path.join(path, f)
+
+def get_testcases(path):
+    for f in get_testcase_filenames(path):
+        yield Testcase(f)
 
 def get_testcase_relative_filename(testcase, relative):
     if relative is None:
         return None
 
-    return os.path.join(os.path.dirname(testcase), relative)
+    return os.path.join(os.path.dirname(testcase.filename), relative)
 
 def get_input_filename(testcase):
     options = get_testcase_options(testcase)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -106,10 +106,6 @@ def get_testcase_filenames(path):
         if f.endswith(testext):
             yield os.path.join(path, f)
 
-def get_testcases(path):
-    for f in get_testcase_filenames(path):
-        yield Testcase(f)
-
 def read_file(filename):
     if not filename or not os.path.isfile(filename):
         # Emulate empty file.

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -13,12 +13,6 @@ rootdir = os.path.dirname(testdir)
 
 sys.path.insert(0, rootdir)
 
-def get_testid(testcase):
-    """Convert a testcase filename into a test case identifier."""
-    name = os.path.splitext(os.path.basename(testcase.filename))[0]
-
-    return name
-
 options_schema = strictyaml.Map({
     'domain': strictyaml.Enum(['c', 'cpp']),
     'directive': strictyaml.Str(),
@@ -42,6 +36,15 @@ class Testcase:
         self.filename = filename
         with open(filename, 'r') as f:
             self.options = strictyaml.load(f.read(), options_schema).data
+
+    def get_testid(self):
+        """Convert a testcase filename into a test case identifier."""
+        name = os.path.splitext(os.path.basename(self.filename))[0]
+
+        return name
+
+def get_testid(testcase):
+    return testcase.get_testid()
 
 def get_testcase_options(testcase):
     return testcase.options

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -110,7 +110,7 @@ def get_examples():
         if not os.path.basename(testcase.filename).startswith('example-'):
             continue
 
-        input_filename = os.path.basename(testenv.get_input_filename(testcase))
+        input_filename = os.path.basename(testcase.get_input_filename())
 
         if input_filename in examples:
             examples[input_filename].append(testcase)

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -68,7 +68,7 @@ def print_example(testcase):
 
     if options.get('example-use-namespace'):
         # Generate namespace from relative path to YAML without extension
-        relative = os.path.relpath(testcase, start=testenv.testdir)
+        relative = os.path.relpath(testcase.filename, start=testenv.testdir)
         relative, _ = os.path.splitext(relative)
 
         namespace = 'namespace_' + re.sub(r'[^a-zA-Z0-9]', '_', relative)
@@ -107,7 +107,7 @@ def get_examples():
     examples = {}
 
     for testcase in testenv.get_testcases(testenv.testdir):
-        if not os.path.basename(testcase).startswith('example-'):
+        if not os.path.basename(testcase.filename).startswith('example-'):
             continue
 
         input_filename = os.path.basename(testenv.get_input_filename(testcase))

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -79,7 +79,7 @@ def print_example(testcase):
         namespace_push = ''
         namespace_pop = ''
 
-    directive_str = testenv.get_directive_string(options)
+    directive_str = testcase.get_directive_string()
 
     print(f'''Directive
 ~~~~~~~~~

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -8,9 +8,7 @@ import re
 import testenv
 
 def get_title(testcase):
-    options = testenv.get_testcase_options(testcase)
-
-    return options.get('example-title')
+    return testcase.options.get('example-title')
 
 def get_title_underline(title):
     return '-' * len(title)
@@ -63,7 +61,7 @@ def print_source(input_filename):
 ''')
 
 def print_example(testcase):
-    options = testenv.get_testcase_options(testcase)
+    options = testcase.options
     domain = options.get('domain')
 
     if options.get('example-use-namespace'):
@@ -95,8 +93,7 @@ Output
 ''')
 
 def testcase_key(testcase):
-    options = testenv.get_testcase_options(testcase)
-    return int(options.get('example-priority', 0))
+    return int(testcase.options.get('example-priority', 0))
 
 def examples_key(item):
     (_, testcases) = item

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -7,6 +7,9 @@ import re
 
 import testenv
 
+class ExampleTestcase(testenv.Testcase):
+    pass
+
 def get_title(testcase):
     return testcase.options.get('example-title')
 
@@ -100,13 +103,15 @@ def examples_key(item):
 
     return min([testcase_key(testcase) for testcase in testcases])
 
+def _get_example_testcases(path):
+    for f in testenv.get_testcase_filenames(path):
+        if os.path.basename(f).startswith('example-'):
+            yield ExampleTestcase(f)
+
 def get_examples():
     examples = {}
 
-    for testcase in testenv.get_testcases(testenv.testdir):
-        if not os.path.basename(testcase.filename).startswith('example-'):
-            continue
-
+    for testcase in _get_example_testcases(testenv.testdir):
         input_filename = os.path.basename(testcase.get_input_filename())
 
         if input_filename in examples:


### PR DESCRIPTION
Another day, another test overhaul :)

This time, add a Testcase class that represents a testcase `.yaml`, and make `testcase` in code always refer to a Testcase object instead of a plain filename. Gradually convert most of the testcase handling into a nice class structure.

Some of the steps are a bit annoying diff-wise, but `git show -w` helps a bit.

A nice feature of the coverage reports: I could run coverage before and after this, compare the results, and observe there's no diff. :)