### PR TITLE
Add support for arranging tests in subdirectories

### DIFF
--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -15,6 +15,10 @@ def _get_suffix(buildername):
 
 class ExtensionTestcase(testenv.Testcase):
     def get_output(self, app, status, warning):
+        # Set root to the directory the testcase yaml is in, because the
+        # filenames in yaml are relative to it.
+        app.config.hawkmoth_root = os.path.dirname(self.filename)
+
         directive_str = self.get_directive_string()
 
         with open(os.path.join(app.srcdir, 'index.rst'), 'w') as f:

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -15,10 +15,6 @@ def _get_suffix(buildername):
 
 class ExtensionTestcase(testenv.Testcase):
     def get_output(self, app, status, warning):
-        input_filename = self.get_input_filename()
-        shutil.copyfile(input_filename,
-                        os.path.join(app.srcdir, os.path.basename(input_filename)))
-
         directive_str = self.get_directive_string()
 
         with open(os.path.join(app.srcdir, 'index.rst'), 'w') as f:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -83,7 +83,7 @@ class CliTestcase(testenv.Testcase):
 
     def get_expected(self):
         return testenv.read_file(self.get_expected_filename()), \
-            testenv.read_file(self.get_stderr_filename())
+            testenv.read_file(self.get_stderr_filename(), optional=True)
 
 def _get_cli_testcases(path):
     for f in testenv.get_testcase_filenames(path):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -57,7 +57,7 @@ class ParserTestcase(testenv.Testcase):
 
     def get_expected(self):
         return testenv.read_file(self.get_expected_filename()), \
-            testenv.read_file(self.get_stderr_filename())
+            testenv.read_file(self.get_stderr_filename(), optional=True)
 
 def _get_parser_testcases(path):
     for f in testenv.get_testcase_filenames(path):

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -101,9 +101,10 @@ def get_testid(testcase):
     return testcase.get_testid()
 
 def get_testcase_filenames(path):
-    for f in sorted(os.listdir(path)):
-        if f.endswith(testext):
-            yield os.path.join(path, f)
+    for root, dirs, files in sorted(os.walk(path)):
+        for f in files:
+            if f.endswith(testext):
+                yield os.path.join(root, f)
 
 def read_file(filename):
     if not filename or not os.path.isfile(filename):

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -108,10 +108,14 @@ def get_testcase_filenames(path):
             if f.endswith(testext):
                 yield os.path.join(root, f)
 
-def read_file(filename):
-    if not filename or not os.path.isfile(filename):
+def read_file(filename, optional=False):
+    if not filename:
+        assert optional
+
         # Emulate empty file.
         return ''
+
+    assert os.path.isfile(filename)
 
     with open(filename, 'r') as f:
         return f.read()

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -94,6 +94,8 @@ class Testcase:
         output_docs, output_errors = self.get_output()
         expect_docs, expect_errors = self.get_expected()
 
+        assert output_docs, 'empty output'
+        assert expect_docs, 'empty expected'
         assert output_docs == expect_docs
         assert output_errors == expect_errors
 


### PR DESCRIPTION
This should enable us to start arranging tests in subdirectories. I played with it a bit, and it seems to work, but I didn't actually include any rearrangement of the files. I threw in some additional asserts in case the files aren't found.

Examples work test-wise, but `make html` will fail if the examples are placed in a subdirectory, because of `hawkmoth_root` config. I think that's fine for now.