### PR TITLE
Process docstring event v2

### DIFF
--- a/doc/built-in-extensions.rst
+++ b/doc/built-in-extensions.rst
@@ -60,6 +60,58 @@ For example:
       :file: file.c
       :transform: javadoc
 
+.. _hawkmoth.ext.napoleon:
+
+hawkmoth.ext.napoleon
+---------------------
+
+This extension provides a bridge from Hawkmoth to the
+:external+sphinx:py:mod:`sphinx.ext.napoleon` extension, using the
+:event:`hawkmoth-process-docstring` event, to support Napoleon style
+documentation comments.
+
+Installation and configuration in ``conf.py``:
+
+.. code-block:: python
+
+   extensions.append('hawkmoth.ext.napoleon')
+
+.. py:data:: hawkmoth_napoleon_transform
+   :type: str
+
+   Name of the transformation to handle. Defaults to ``'napoleon'``. Only
+   convert the comment if the ``transform`` option matches this name, otherwise
+   do nothing.
+
+For example:
+
+.. code-block:: python
+   :caption: conf.py
+
+   extensions.append('hawkmoth.ext.napoleon')
+   hawkmoth_transform_default = 'napoleon'
+
+.. code-block:: c
+   :caption: file.c
+
+   /**
+    * The baznicator.
+    *
+    * Args:
+    *     foo: The Foo parameter.
+    *     bar: The Bar parameter.
+    *
+    * Returns:
+    *     0 on success, non-zero error code on error.
+    */
+   int baz(int foo, int bar);
+
+.. code-block:: rst
+   :caption: api.rst
+
+   .. c:autofunction:: baz
+      :file: file.c
+
 .. _hawkmoth.ext.transformations:
 
 hawkmoth.ext.transformations

--- a/doc/built-in-extensions.rst
+++ b/doc/built-in-extensions.rst
@@ -6,6 +6,60 @@ Built-In Extensions
 Hawkmoth is :ref:`extensible <extending>`, and ships with some built-in
 extensions.
 
+.. _hawkmoth.ext.javadoc:
+
+hawkmoth.ext.javadoc
+--------------------
+
+This extension converts Javadoc_ comments to reStructuredText, using the
+:event:`hawkmoth-process-docstring` event.
+
+.. note::
+
+   The Javadoc support is rudimentary at best.
+
+.. _Javadoc: https://www.oracle.com/technetwork/java/javase/documentation/javadoc-137458.html
+
+Installation and configuration in ``conf.py``:
+
+.. code-block:: python
+
+   extensions.append('hawkmoth.ext.javadoc')
+
+.. py:data:: hawkmoth_javadoc_transform
+   :type: str
+
+   Name of the transformation to handle. Defaults to ``'javadoc'``. Only convert
+   the comment if the ``transform`` option matches this name, otherwise do
+   nothing.
+
+For example:
+
+.. code-block:: python
+   :caption: conf.py
+
+   extensions.append('hawkmoth.ext.javadoc')
+
+.. code-block:: c
+   :caption: file.c
+
+   /**
+    * The baznicator.
+    *
+    * @param foo The Foo parameter.
+    * @param bar The Bar parameter.
+    * @return 0 on success, non-zero error code on error.
+    * @since v0.1
+    */
+   int baz(int foo, int bar);
+
+.. code-block:: rst
+   :caption: api.rst
+
+   .. c:autofunction:: baz
+      :file: file.c
+      :transform: javadoc
+
 .. _hawkmoth.ext.transformations:
 
 hawkmoth.ext.transformations

--- a/doc/built-in-extensions.rst
+++ b/doc/built-in-extensions.rst
@@ -1,0 +1,70 @@
+.. _built-in-extensions:
+
+Built-In Extensions
+===================
+
+Hawkmoth is :ref:`extensible <extending>`, and ships with some built-in
+extensions.
+
+.. _hawkmoth.ext.transformations:
+
+hawkmoth.ext.transformations
+----------------------------
+
+This extension handles the :py:data:`cautodoc_transformations` feature, using
+the :event:`hawkmoth-process-docstring` event.
+
+.. note::
+
+   Going forward, it's recommended to handle transformations using the event
+   directly instead of :py:data:`cautodoc_transformations`. This built-in
+   extension provides backward compatibility for the functionality.
+
+   For now, this extension is loaded by default, and the installation step below
+   is not strictly necessary. This will change in the future.
+
+Installation and configuration in ``conf.py``:
+
+.. code-block:: python
+
+   extensions.append('hawkmoth.ext.transformations')
+
+.. py:data:: cautodoc_transformations
+   :type: dict
+
+   Transformation functions for the :rst:dir:`c:autodoc` directive ``transform``
+   option. This is a dictionary that maps names to functions. The names can be
+   used in the directive ``transform`` option. The functions are expected to
+   take a (multi-line) comment string as a parameter, and return the transformed
+   string. This can be used to perform custom conversions of the comments,
+   including, but not limited to, Javadoc-style compat conversions.
+
+   The special key ``None``, if present, is used to convert everything, unless
+   overridden in the directive ``transform`` option. The special value ``None``
+   means no transformation is to be done.
+
+   For example, this configuration would transform everything using
+   ``default_transform`` function by default, unless overridden in the directive
+   ``transform`` option with ``javadoc`` or ``none``. The former would use
+   ``javadoc_transform`` function, and the latter would bypass transform
+   altogether.
+
+   .. code-block:: python
+
+      cautodoc_transformations = {
+          None: default_transform,
+          'javadoc': javadoc_transform,
+          'none': None,
+      }
+
+   The example below shows how to use Hawkmoth's existing compat functions in
+   ``conf.py``.
+
+   .. code-block:: python
+
+      from hawkmoth.util import doccompat
+      cautodoc_transformations = {
+          'javadoc-basic': doccompat.javadoc,
+          'javadoc-liberal': doccompat.javadoc_liberal,
+          'kernel-doc': doccompat.kerneldoc,
+      }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -220,3 +220,4 @@ intersphinx_mapping = {
 
 def setup(app):
     app.add_object_type('confval', 'confval')
+    app.add_object_type('event', 'event', 'pair: %s; event')

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -67,7 +67,6 @@ except ImportError:
     extensions.append('automock')
 
 hawkmoth_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../test/examples')
-hawkmoth_javadoc_transform = 'javadoc-liberal'
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,22 +50,15 @@ needs_sphinx = '4.4'
 # This is not a good example to follow in regular documentation.
 try:
     import hawkmoth
-    from hawkmoth.util import doccompat, readthedocs
-    from sphinx.ext.napoleon import docstring, Config
+    from hawkmoth.util import readthedocs
 
     readthedocs.clang_setup()
 
     extensions.append('hawkmoth')
+    extensions.append('hawkmoth.ext.napoleon')
+    extensions.append('hawkmoth.ext.javadoc')
     tags.add('have_hawkmoth')
 
-    def napoleon_transform(comment):
-        config = Config(napoleon_use_rtype=False)
-        return str(docstring.GoogleDocstring(comment, config))
-
-    cautodoc_transformations = {
-        'napoleon': napoleon_transform,
-        'javadoc-liberal': doccompat.javadoc_liberal,
-    }
 except ImportError:
     sys.stderr.write('Warning: Failed to import hawkmoth. Mocking results.\n')
     sys.path.insert(0, os.path.abspath('ext'))
@@ -74,6 +67,7 @@ except ImportError:
     extensions.append('automock')
 
 hawkmoth_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../test/examples')
+hawkmoth_javadoc_transform = 'javadoc-liberal'
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -27,9 +27,7 @@ generate documentation, but offers no control over what gets included.
       Override :data:`hawkmoth_transform_default` for the ``transform``
       parameter value of the :event:`hawkmoth-process-docstring` event.
 
-      Name of the transformation function specified in
-      :data:`cautodoc_transformations` to use for converting the comments. This
-      value overrides the default in :data:`cautodoc_transformations`.
+      See also :ref:`hawkmoth.ext.transformations`.
 
    .. rst:directive:option:: clang
       :type: text

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -24,6 +24,9 @@ generate documentation, but offers no control over what gets included.
    .. rst:directive:option:: transform
       :type: text
 
+      Override :data:`hawkmoth_transform_default` for the ``transform``
+      parameter value of the :event:`hawkmoth-process-docstring` event.
+
       Name of the transformation function specified in
       :data:`cautodoc_transformations` to use for converting the comments. This
       value overrides the default in :data:`cautodoc_transformations`.

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -357,12 +357,12 @@ Directive
 .. code-block:: rest
 
    .. c:autodoc:: compat.c
-      :transform: javadoc-liberal
+      :transform: javadoc
 
 Output
 ~~~~~~
 
 .. c:autodoc:: compat.c
-   :transform: javadoc-liberal
+   :transform: javadoc
 
 

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -1,0 +1,38 @@
+.. _extending:
+
+Extending
+=========
+
+Hawkmoth is a Sphinx extension that can be further extended with other Sphinx
+extensions.
+
+Events
+------
+
+See :external+sphinx:py:meth:`sphinx.application.Sphinx.connect` on how to
+connect events.
+
+.. event:: hawkmoth-process-docstring
+
+   .. py:function:: func(app, lines, transform, options)
+      :noindex:
+
+      :param app: The Sphinx application object
+      :type app: :external+sphinx:py:class:`sphinx.application.Sphinx`
+      :param list[str] lines: The comment being processed
+      :param str transform: Transformation
+      :param dict options: The directive options
+
+   This is similar to the :external+sphinx:event:`autodoc-process-docstring`
+   event in the :external+sphinx:py:mod:`sphinx.ext.autodoc` extension.
+
+   The *lines* argument is the documentation comment, with the comment markers
+   removed, as a list of strings that the event handler may modify in-place.
+
+   The *transform* argument is the ``transform`` option of the :ref:`directive
+   <directives>` being processed, defaulting to
+   :data:`hawkmoth_transform_default`, which defaults to ``None``. The event
+   handler may use this to decide what, if anything, should be done to *lines*.
+
+   The *options* argument is a dictionary with all the options given to the
+   directive being processed.

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -15,6 +15,9 @@ details.
 See :ref:`installation` on how to install the Hawkmoth package and its
 dependencies.
 
+Hawkmoth itself is :ref:`extensible <extending>`, and ships with some
+:ref:`built-in extensions <built-in-extensions>`.
+
 Usage
 -----
 
@@ -31,7 +34,10 @@ For example:
 Configuration
 -------------
 
-The extension has a few configuration options that can be set in ``conf.py``:
+The extension has a few configuration options that can be set in ``conf.py``.
+
+See also additional configuration options in the :ref:`built-in extensions
+<built-in-extensions>`.
 
 .. py:data:: hawkmoth_root
    :type: str
@@ -55,46 +61,6 @@ The extension has a few configuration options that can be set in ``conf.py``:
    :event:`hawkmoth-process-docstring` event. It can be overriden with the
    ``transform`` option of the :ref:`directives <directives>`. Defaults to
    ``None``.
-
-.. py:data:: cautodoc_transformations
-   :type: dict
-
-   Transformation functions for the :rst:dir:`c:autodoc` directive ``transform``
-   option. This is a dictionary that maps names to functions. The names can be
-   used in the directive ``transform`` option. The functions are expected to
-   take a (multi-line) comment string as a parameter, and return the transformed
-   string. This can be used to perform custom conversions of the comments,
-   including, but not limited to, Javadoc-style compat conversions.
-
-   The special key ``None``, if present, is used to convert everything, unless
-   overridden in the directive ``transform`` option. The special value ``None``
-   means no transformation is to be done.
-
-   For example, this configuration would transform everything using
-   ``default_transform`` function by default, unless overridden in the directive
-   ``transform`` option with ``javadoc`` or ``none``. The former would use
-   ``javadoc_transform`` function, and the latter would bypass transform
-   altogether.
-
-   .. code-block:: python
-
-      cautodoc_transformations = {
-          None: default_transform,
-          'javadoc': javadoc_transform,
-          'none': None,
-      }
-
-   The example below shows how to use Hawkmoth's existing compat functions in
-   ``conf.py``.
-
-   .. code-block:: python
-
-      from hawkmoth.util import doccompat
-      cautodoc_transformations = {
-          'javadoc-basic': doccompat.javadoc,
-          'javadoc-liberal': doccompat.javadoc_liberal,
-          'kernel-doc': doccompat.kerneldoc,
-      }
 
 .. py:data:: hawkmoth_clang
    :type: list

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -48,6 +48,14 @@ The extension has a few configuration options that can be set in ``conf.py``:
       import os
       hawkmoth_root = os.path.abspath('my/sources/dir')
 
+.. py:data:: hawkmoth_transform_default
+   :type: str
+
+   The default transform parameter to be passed to the
+   :event:`hawkmoth-process-docstring` event. It can be overriden with the
+   ``transform`` option of the :ref:`directives <directives>`. Defaults to
+   ``None``.
+
 .. py:data:: cautodoc_transformations
    :type: dict
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,6 +37,7 @@ Contents:
    syntax
    examples
    extending
+   built-in-extensions
    troubleshooting
 
 Indices and tables

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,6 +36,7 @@ Contents:
    directives
    syntax
    examples
+   extending
    troubleshooting
 
 Indices and tables

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -7,8 +7,8 @@ For the :any:`c:autodoc` directive to work, the C source code must be
 documented using specific documentation comment style, and the comments must
 follow reStructuredText markup.
 
-Optionally, there's limited support for some Javadoc_ and Doxygen_ style
-constructs for compatibility.
+Optionally, the syntax may be :ref:`extended <extending-the-syntax>` to support
+e.g. Javadoc and Napoleon style comments.
 
 See :ref:`the examples section <examples>` for a quick tour of what's possible,
 and read on for documentation comment formatting details.
@@ -65,31 +65,20 @@ values, and arbitrary other data:
 
 .. _field lists: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists
 
-Compatibility
--------------
+.. _extending-the-syntax:
 
-Hawkmoth supports limited Javadoc_ and Doxygen_ style constructs for
-compatibility. See the :ref:`extension documentation <extension>` on how to
-enable the support.
+Extending the Syntax
+--------------------
 
-.. code-block:: c
+Hawkmoth supports :ref:`extending <extending>` the syntax using :ref:`built-in
+<built-in-extensions>` and custom extensions that convert the comments to
+reStructuredText.
 
-  /**
-   * The baznicator.
-   *
-   * @param foo The Foo parameter.
-   * @param bar The Bar parameter.
-   * @return 0 on success, non-zero error code on error.
-   * @since v0.1
-   */
-  int baz(int foo, int bar);
-
-.. warning:: The compatibility support and its documentation are a
-             work-in-progress.
+The :ref:`hawkmoth.ext.javadoc` extension provides limited support for Javadoc_
+style comments, and the :ref:`hawkmoth.ext.napoleon` extension provides support
+for :external+sphinx:py:mod:`sphinx.ext.napoleon` style comments.
 
 .. _Javadoc: https://www.oracle.com/technetwork/java/javase/documentation/javadoc-137458.html
-
-.. _Doxygen: http://doxygen.nl/
 
 Cross-Referencing C Constructs
 ------------------------------

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -63,17 +63,10 @@ class _AutoBaseDirective(SphinxDirective):
         tropt = self.options.get('transform')
 
         if transformations is None:
-            if tropt is not None:
-                self.logger.warning('transform specified without cautodoc_transformations config.',
-                                    location=(self.env.docname, self.lineno))
-
             return None
 
         # Note: None is a valid key for default.
         if tropt not in transformations:
-            if tropt is not None:
-                self.logger.warning(f'unknown transformation "{tropt}".',
-                                    location=(self.env.docname, self.lineno))
             return None
 
         # Note: None is a valid value for no transformation.

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -86,6 +86,10 @@ class _AutoBaseDirective(SphinxDirective):
             text = transform(text)
             lines[:] = [line for line in text.splitlines()]
 
+        transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
+
+        self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
+
     def __parse(self, filename):
         # Always pass `-xc++` to the compiler on 'cpp' domain as the first
         # option so that the user can override it.
@@ -304,6 +308,8 @@ def setup(app):
         'env', [list]
     )
 
+    app.add_config_value('hawkmoth_transform_default', None, 'env', [str])
+
     app.add_directive_to_domain('c', 'autodoc', CAutoDocDirective)
     app.add_directive_to_domain('c', 'autovar', CAutoVarDirective)
     app.add_directive_to_domain('c', 'autotype', CAutoTypeDirective)
@@ -322,6 +328,8 @@ def setup(app):
     app.add_directive_to_domain('cpp', 'automacro', CppAutoMacroDirective)
     app.add_directive_to_domain('cpp', 'autofunction', CppAutoFunctionDirective)
     app.add_directive_to_domain('cpp', 'autoclass', CppAutoClassDirective)
+
+    app.add_event('hawkmoth-process-docstring')
 
     return dict(version=__version__,
                 parallel_read_safe=True, parallel_write_safe=True)

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -58,27 +58,7 @@ class _AutoBaseDirective(SphinxDirective):
 
         return clang_args
 
-    def __get_transform(self):
-        transformations = self.env.config.cautodoc_transformations
-        tropt = self.options.get('transform')
-
-        if transformations is None:
-            return None
-
-        # Note: None is a valid key for default.
-        if tropt not in transformations:
-            return None
-
-        # Note: None is a valid value for no transformation.
-        return transformations.get(tropt)
-
     def __transform(self, lines):
-        transform = self.__get_transform()
-        if transform:
-            text = '\n'.join(lines)
-            text = transform(text)
-            lines[:] = [line for line in text.splitlines()]
-
         transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
 
         self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
@@ -288,7 +268,6 @@ def setup(app):
 
     app.add_config_value('cautodoc_root', None, 'env', [str])
     app.add_config_value('cautodoc_clang', None, 'env', [list])
-    app.add_config_value('cautodoc_transformations', None, 'env', [dict])
 
     app.add_config_value(
         'hawkmoth_root',
@@ -323,6 +302,9 @@ def setup(app):
     app.add_directive_to_domain('cpp', 'autoclass', CppAutoClassDirective)
 
     app.add_event('hawkmoth-process-docstring')
+
+    # Setup transformations for compatibility.
+    app.setup_extension('hawkmoth.ext.transformations')
 
     return dict(version=__version__,
                 parallel_read_safe=True, parallel_write_safe=True)

--- a/hawkmoth/ext/javadoc/__init__.py
+++ b/hawkmoth/ext/javadoc/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2023, Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+
+from hawkmoth.util.doccompat import javadoc_liberal
+
+def _process_docstring(app, lines, transform, options):
+    if transform != app.config.hawkmoth_javadoc_transform:
+        return
+
+    comment = '\n'.join(lines)
+    comment = javadoc_liberal(comment)
+    lines[:] = comment.splitlines()[:]
+
+def setup(app):
+    app.setup_extension('hawkmoth')
+
+    app.add_config_value('hawkmoth_javadoc_transform', 'javadoc', 'env', [str])
+
+    app.connect('hawkmoth-process-docstring', _process_docstring)
+
+    return {
+        'parallel_read_safe': True,
+    }

--- a/hawkmoth/ext/napoleon/__init__.py
+++ b/hawkmoth/ext/napoleon/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023, Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+
+from sphinx.ext.napoleon import _process_docstring
+
+def _process_docstring_proxy(app, lines, transform, options):
+    if transform != app.config.hawkmoth_napoleon_transform:
+        return
+
+    # HACK: The Napoleon _process_docstring() function is for connecting to the
+    # Sphinx autodoc autodoc-process-docstring event. It's ugly to call it
+    # directly, but the alternative is duplicating all it does, which is also
+    # ugly.
+
+    return _process_docstring(app, None, None, None, options, lines)
+
+def setup(app):
+    app.setup_extension('sphinx.ext.napoleon')
+    app.setup_extension('hawkmoth')
+
+    app.add_config_value('hawkmoth_napoleon_transform', 'napoleon', 'env', [str])
+
+    app.connect('hawkmoth-process-docstring', _process_docstring_proxy)
+
+    return {
+        'parallel_read_safe': True,
+    }

--- a/hawkmoth/ext/transformations/__init__.py
+++ b/hawkmoth/ext/transformations/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023, Jani Nikula <jani@nikula.org>
+# Licensed under the terms of BSD 2-Clause, see LICENSE for details.
+
+def _process_docstring(app, lines, transform, options):
+    transformations = app.config.cautodoc_transformations
+    tropt = options.get('transform')
+
+    if transformations is None:
+        return
+
+    # Note: None is a valid key for default.
+    if tropt not in transformations:
+        return
+
+    # Note: None is a valid value for no transformation.
+    transform = transformations.get(tropt)
+    if transform is None:
+        return
+
+    comment = '\n'.join(lines)
+    comment = transform(comment)
+    lines[:] = comment.splitlines()[:]
+
+def setup(app):
+    app.add_config_value('cautodoc_transformations', None, 'env', [dict])
+
+    # Run before event handlers with default priority.
+    app.connect('hawkmoth-process-docstring', _process_docstring, 400)
+
+    return {
+        'parallel_read_safe': True,
+    }

--- a/test/conf.py
+++ b/test/conf.py
@@ -50,7 +50,7 @@ def napoleon_transform(comment):
 
 cautodoc_transformations = {
     'napoleon': napoleon_transform,
-    'javadoc-liberal': doccompat.javadoc_liberal,
+    'javadoc': doccompat.javadoc_liberal,
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/test/examples/compat.c
+++ b/test/examples/compat.c
@@ -4,8 +4,11 @@ enum mode;
 /**
  * Compat comment transformations.
  *
- * Transformations require ``cautodoc_transformations`` configuration in
- * ``conf.py``. In this example, a transformation is used to support
+ * Documentation comments can be processed using the hawkmoth-process-docstring
+ * Sphinx event. You can use the built-in extensions for this, or create your
+ * own.
+ *
+ * In this example, hawkmoth.ext.javadoc built-in extension is used to support
  * Javadoc-style documentation comments.
  *
  * @param list The list to frob.

--- a/test/examples/compat.rst
+++ b/test/examples/compat.rst
@@ -3,8 +3,11 @@
 
    Compat comment transformations.
 
-   Transformations require ``cautodoc_transformations`` configuration in
-   ``conf.py``. In this example, a transformation is used to support
+   Documentation comments can be processed using the hawkmoth-process-docstring
+   Sphinx event. You can use the built-in extensions for this, or create your
+   own.
+
+   In this example, hawkmoth.ext.javadoc built-in extension is used to support
    Javadoc-style documentation comments.
 
 

--- a/test/examples/compat.yaml
+++ b/test/examples/compat.yaml
@@ -3,7 +3,7 @@ directive: autodoc
 directive-arguments:
   - compat.c
 directive-options:
-  transform: javadoc-liberal
+  transform: javadoc
 example-title: Compat
 example-priority: 95
 expected: compat.rst

--- a/test/examples/transform.c
+++ b/test/examples/transform.c
@@ -1,9 +1,12 @@
 /**
  * Custom comment transformations.
  *
- * Transformations require ``cautodoc_transformations`` configuration in
- * ``conf.py``. In this example, Napoleon is used to interpret another
- * documentation comment format.
+ * Documentation comments can be processed using the hawkmoth-process-docstring
+ * Sphinx event. You can use the built-in extensions for this, or create your
+ * own.
+ *
+ * In this example, hawkmoth.ext.napoleon built-in extension is used to support
+ * Napoleon-style documentation comments.
  *
  * Args:
  *     foo: This is foo.

--- a/test/examples/transform.rst
+++ b/test/examples/transform.rst
@@ -3,9 +3,12 @@
 
    Custom comment transformations.
 
-   Transformations require ``cautodoc_transformations`` configuration in
-   ``conf.py``. In this example, Napoleon is used to interpret another
-   documentation comment format.
+   Documentation comments can be processed using the hawkmoth-process-docstring
+   Sphinx event. You can use the built-in extensions for this, or create your
+   own.
+
+   In this example, hawkmoth.ext.napoleon built-in extension is used to support
+   Napoleon-style documentation comments.
 
    :param foo: This is foo.
    :param bar: This is bar.


### PR DESCRIPTION
v2 of #129 hopefully with all the comments resolved.

I've added some commits cleaning up related documentation, and expanded on the built-in extension usage. There's more to do, surely, but I'm hoping this is a good first step.

I also pushed the rebased but otherwise unchanged version of #129 to `process-docstring-event-v1-rebased` which may be helpful in comparing the differences between the two.

