### PR TITLE
Parser autodoc tests

### DIFF
--- a/test/c/autostruct.rst
+++ b/test/c/autostruct.rst
@@ -22,3 +22,4 @@
 
       :param foo: the foo
       :param bar: the bar
+

--- a/test/c/autovariable-fnptr-array.rst
+++ b/test/c/autovariable-fnptr-array.rst
@@ -1,5 +1,5 @@
 
-.. c:var::  void (*function_pointer_array[5])(void)
+.. c:var:: void (*function_pointer_array[5])(void)
 
    array of function pointers
 

--- a/test/cpp/autoclass.rst
+++ b/test/cpp/autoclass.rst
@@ -4,7 +4,7 @@
    Classy foo.
 
 
-   .. cpp:member:: mutable int mutable_member
+   .. cpp:member:: public mutable int mutable_member
 
       A mutable member.
 

--- a/test/cpp/autostruct.rst
+++ b/test/cpp/autostruct.rst
@@ -6,19 +6,20 @@
    Woohoo.
 
 
-   .. cpp:member:: int array_member[5]
+   .. cpp:member:: public int array_member[5]
 
       array member
 
 
-   .. cpp:member:: int (*function_pointer_member)(int, int)
+   .. cpp:member:: public int (*function_pointer_member)(int, int)
 
       function pointer member with parameter names omitted
 
 
-   .. cpp:member:: int (*other_function_pointer_member)(int foo, int bar)
+   .. cpp:member:: public int (*other_function_pointer_member)(int foo, int bar)
 
       function pointer member with parameter names
 
       :param foo: the foo
       :param bar: the bar
+

--- a/test/cpp/autovariable-fnptr-array.rst
+++ b/test/cpp/autovariable-fnptr-array.rst
@@ -1,5 +1,5 @@
 
-.. cpp:var::  void (*function_pointer_array[5])(void)
+.. cpp:var:: void (*function_pointer_array[5])(void)
 
    array of function pointers
 

--- a/test/examples/autostruct.rst
+++ b/test/examples/autostruct.rst
@@ -4,7 +4,7 @@
    Linked list node.
 
 
-   .. c:member:: struct list * next
+   .. c:member:: struct list *next
 
       Next node.
 

--- a/test/examples/autounion.rst
+++ b/test/examples/autounion.rst
@@ -3,6 +3,7 @@
 
    Onion documentation.
 
+
    .. c:member:: int yellow
 
       Yellow onion.

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -38,7 +38,7 @@ class ParserTestcase(testenv.Testcase):
         directive_options = options.get('directive-options', {})
 
         clang_args.extend(directive_options.get('clang', []))
-        comments, errors = parse(input_filename, domain=domain, clang_args=clang_args)
+        root, errors = parse(input_filename, domain=domain, clang_args=clang_args)
 
         tropt = directive_options.get('transform')
         if tropt is not None:
@@ -46,9 +46,10 @@ class ParserTestcase(testenv.Testcase):
         else:
             transform = None
 
-        for comment in comments.walk():
-            lines = comment.get_docstring(transform=lambda lines: _transform(transform, lines))
-            docs_str += '\n'.join(lines) + '\n'
+        for docstrings in root.walk(recurse=False):
+            for docstr in docstrings.walk():
+                lines = docstr.get_docstring(transform=lambda lines: _transform(transform, lines))
+                docs_str += '\n'.join(lines) + '\n'
 
         for error in errors:
             errors_str += f'{error.level.name}: {os.path.basename(error.filename)}:{error.line}: {error.message}\n'  # noqa: E501

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018, Jani Nikula <jani@nikula.org>
+# Copyright (c) 2018-2023, Jani Nikula <jani@nikula.org>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 
 import os
@@ -40,7 +40,7 @@ class ParserTestcase(testenv.Testcase):
         clang_args.extend(options.get('clang', []))
         comments, errors = parse(input_filename, domain=domain, clang_args=clang_args)
 
-        tropt = options.pop('transform', None)
+        tropt = options.get('transform')
         if tropt is not None:
             transform = conf.cautodoc_transformations[tropt]
         else:

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -35,12 +35,12 @@ class ParserTestcase(testenv.Testcase):
 
         input_filename = self.get_input_filename()
 
-        options = options.get('directive-options', {})
+        directive_options = options.get('directive-options', {})
 
-        clang_args.extend(options.get('clang', []))
+        clang_args.extend(directive_options.get('clang', []))
         comments, errors = parse(input_filename, domain=domain, clang_args=clang_args)
 
-        tropt = options.get('transform')
+        tropt = directive_options.get('transform')
         if tropt is not None:
             transform = conf.cautodoc_transformations[tropt]
         else:


### PR DESCRIPTION
Improve parser whitespace robustness for the non-autodoc auto* directives. See the last commit message for details.