### PR TITLE
changelog: start listing changes since 0.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,39 @@ Unreleased `master`_
 
 :Date: YYYY-MM-DD
 
+Added
+~~~~~
+
+* Early support for documenting C++ (contributions courtesy of `Critical Software`_)
+* Support for extending documentation comment parsing and transformations via
+  ``hawkmoth-process-docstring`` event
+* ``hawkmoth_transform_default`` configuration option for the
+  ``hawkmoth-process-docstring`` event
+* ``hawkmoth_root`` configuration option to replace ``cautodoc_root``
+* ``hawkmoth_clang`` configuration option to replace ``cautodoc_clang``
+* Built-in extensions for Javadoc and Napoleon comment handling
+
+.. _Critical Software: https://www.criticalsoftware.com/
+
+Changed
+~~~~~~~
+
+* Typedefed anonymous struct, union, and enum parsing to be more explicit
+* ``cautodoc_transformations`` handling moved to a built-in extension
+* Lots of test suite refactoring and cleanups
+
+Deprecated
+~~~~~~~~~~
+
+* ``cautodoc_root`` configuration option in favour of ``hawkmoth_root``
+* ``cautodoc_clang`` configuration option in favour of ``hawkmoth_clang``
+
+Removed
+~~~~~~~
+
+* ``cautodoc_compat`` configuration option
+* ``compat`` directive option
+
 Hawkmoth `0.12.0`_
 ------------------
 


### PR DESCRIPTION
Start listing changes since 0.12, with hopes of gearing towards a 0.13 release in the near future. There's been a lot of changes since 0.12, maybe more than in any other release, and I'd like to get it out sooner rather than later. (Release early, release often, and all that.)

@BrunoMSantos How does the hat-tip to your employer look like? 

I think the main blockers for 0.13 are documenting the C++ support, as well as adding any C++ features that you think we absolutely need before making a release. Not to put any pressure on you. ;)

I'm also fine with downgrading "Support for documenting C++" to "Initial support for documenting C++", depending on the level of support and/or boasting.
