### PR TITLE
Hawkmoth process signature proof-of-concept

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -211,6 +211,12 @@ intersphinx_mapping = {
     'sphinx': ('https://www.sphinx-doc.org/en/master', None)
 }
 
+def _process_signature(app, lines, options):
+    # Yuck.
+    for i in range(len(lines)):
+        lines[i] = lines[i].replace('_Bool', 'bool')
+
 def setup(app):
     app.add_object_type('confval', 'confval')
     app.add_object_type('event', 'event', 'pair: %s; event')
+    app.connect('hawkmoth-process-signature', _process_signature)

--- a/hawkmoth/__init__.py
+++ b/hawkmoth/__init__.py
@@ -90,16 +90,21 @@ class _AutoBaseDirective(SphinxDirective):
 
         self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
 
+    def __process_signature(self, lines):
+        self.env.app.emit('hawkmoth-process-signature', lines, self.options)
+
     def __get_docstrings(self, viewlist, filename):
         root = self.__parse(filename)
 
         process_docstring = lambda lines: self.__process_docstring(lines)
+        process_signature = lambda lines: self.__process_signature(lines)
 
         for docstrings in root.walk(recurse=False, filter_types=self._docstring_types,
                                     filter_names=self._get_names()):
             for docstr in docstrings.walk(filter_names=self._get_members()):
                 lineoffset = docstr.get_line() - 1
-                lines = docstr.get_docstring(transform=process_docstring)
+                lines = docstr.get_docstring(transform=process_docstring,
+                                             process_signature=process_signature)
                 for line in lines:
                     viewlist.append(line, filename, lineoffset)
                     lineoffset += 1
@@ -304,6 +309,7 @@ def setup(app):
     app.add_directive_to_domain('cpp', 'autoclass', CppAutoClassDirective)
 
     app.add_event('hawkmoth-process-docstring')
+    app.add_event('hawkmoth-process-signature')
 
     # Setup transformations for compatibility.
     app.setup_extension('hawkmoth.ext.transformations')

--- a/hawkmoth/docstring.py
+++ b/hawkmoth/docstring.py
@@ -159,9 +159,14 @@ class Docstring():
         """
         lines[:] = ['   ' * nest + line if line else '' for line in lines]
 
-    def get_docstring(self, transform=None):
+    def get_docstring(self, transform=None, process_signature=None):
         header_lines = self._get_header_lines()
         comment_lines = self._get_comment_lines()
+
+        # FIXME: Likely better to call with one line? Although this allows
+        # adding :noindex: etc.
+        if process_signature is not None:
+            process_signature(header_lines)
 
         # FIXME: This changes the number of lines in output. This impacts the
         # error reporting via meta['line']. Adjust meta to take this into

--- a/test/examples/autostruct.rst
+++ b/test/examples/autostruct.rst
@@ -13,3 +13,8 @@
 
       Data.
 
+
+   .. c:member:: _Bool x
+
+      Bool.
+

--- a/test/examples/struct.c
+++ b/test/examples/struct.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 /**
  * Linked list node.
  */
@@ -7,4 +9,7 @@ struct list {
 
 	/** Data. */
 	int data;
+
+	/** Bool. */
+	bool x;
 };

--- a/test/examples/struct.rst
+++ b/test/examples/struct.rst
@@ -13,3 +13,8 @@
 
       Data.
 
+
+   .. c:member:: _Bool x
+
+      Bool.
+

--- a/test/examples/variable.c
+++ b/test/examples/variable.c
@@ -1,3 +1,10 @@
+#include <stdbool.h>
+
+/**
+ * Let's see.
+ */
+bool x;
+
 /**
  * The name says it all.
  */

--- a/test/examples/variable.rst
+++ b/test/examples/variable.rst
@@ -1,4 +1,9 @@
 
+.. c:var:: _Bool x
+
+   Let's see.
+
+
 .. c:var:: const int meaning_of_life
 
    The name says it all.


### PR DESCRIPTION
I looked at #92 when going through the issues, and did a quick hack towards a proof-of-concept `hawkmoth-process-signature` event.

I'm not pursuing this for the next release, but it's something to consider in the future. Looks like this could be fairly simple. You can pretty nicely convert `_Bool` to `bool` if you like, with no hardcoded stuff in the parser. Maybe users want to annotate other stuff (where the clang cursor might be useful too).

Food for though, @BrunoMSantos 
