### PR TITLE
parser: remove dead path

### DIFF
--- a/hawkmoth/parser.py
+++ b/hawkmoth/parser.py
@@ -478,10 +478,6 @@ def _type_definition_fixup(cursor):
     if cursor.spelling == '':
         return None
 
-    storage_class = _get_storage_class(cursor)
-    if storage_class:
-        type_elem.append(storage_class)
-
     type_elem.extend(_specifiers_fixup(cursor, cursor.type))
 
     colon_suffix = ''


### PR DESCRIPTION
Type definitions have no storage class. This was found during refactoring of the code, but can be confirmed in the coverage report and in the fact that the unit tests still pass that the true path was never followed.