### PR TITLE
doc: document the C++ support

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -4,18 +4,21 @@ Directives
 ==========
 
 Hawkmoth provides several new directives for incorporating :ref:`documentation
-comments <syntax>` from C source files into the reStructuredText document. There
-are three main types of directives, for incorporating documentation from entire
-files, for single objects, and for composite objects optionally with members.
+comments <syntax>` from C/C++ source files into the reStructuredText document.
+There are three main types of directives, for incorporating documentation from
+entire files, for single objects, and for composite objects optionally with
+members.
 
 Source Files
 ------------
 
-The :rst:dir:`c:autodoc` directive simply includes all the documentation
-comments from any number of files. This is the most basic and quickest way to
-generate documentation, but offers no control over what gets included.
+The :rst:dir:`c:autodoc` and :rst:dir:`cpp:autodoc` directives simply include
+all the documentation comments from any number of files. This is the most basic
+and quickest way to generate documentation, but offers no control over what gets
+included.
 
 .. rst:directive:: .. c:autodoc:: filename-pattern [...]
+.. rst:directive:: .. cpp:autodoc:: filename-pattern [...]
 
    Incorporate documentation comments from the files specified by the space
    separated list of filename patterns given as arguments. The patterns are
@@ -48,13 +51,15 @@ Variables, Types, Macros, and Functions
 ---------------------------------------
 
 The :rst:dir:`c:autovar`, :rst:dir:`c:autotype`, :rst:dir:`c:automacro`, and
-:rst:dir:`c:autofunction` directives incorporate the documentation comment for
-the specified object in the specified file.
+:rst:dir:`c:autofunction` directives and their C++ domain counterparts
+incorporate the documentation comment for the specified object in the specified
+file.
 
-The directives support all the same directive options as :rst:dir:`c:autodoc`,
-adding the ``file`` option.
+The directives support all the same directive options as :rst:dir:`c:autodoc`
+and :rst:dir:`cpp:autodoc`, adding the ``file`` option.
 
 .. rst:directive:: .. c:autovar:: name
+.. rst:directive:: .. cpp:autovar:: name
 
    Incorporate the documentation comment for the variable ``name`` in the file
    ``file``.
@@ -74,6 +79,7 @@ adding the ``file`` option.
          :file: example_file.c
 
 .. rst:directive:: .. c:autotype:: name
+.. rst:directive:: .. cpp:autotype:: name
 
    Same as :rst:dir:`c:autovar` but for typedefs.
 
@@ -83,8 +89,16 @@ adding the ``file`` option.
          :file: example_file.c
 
 .. rst:directive:: .. c:automacro:: name
+.. rst:directive:: .. cpp:automacro:: name
 
    Same as :rst:dir:`c:autovar` but for macros, including function-like macros.
+
+   .. note::
+
+      The :external+sphinx:ref:`C++ Domain <cpp-domain>` does not have a
+      ``cpp:macro`` directive, so all macros are always in the
+      :external+sphinx:ref:`C Domain <c-domain>`. This affects cross-referencing
+      them; see :ref:`cross-referencing` for details.
 
    .. code-block:: rst
 
@@ -92,6 +106,7 @@ adding the ``file`` option.
          :file: example_file.c
 
 .. rst:directive:: .. c:autofunction:: name
+.. rst:directive:: .. cpp:autofunction:: name
 
    Same as :rst:dir:`c:autovar` but for functions. (Use :rst:dir:`c:automacro`
    for function-like macros.)
@@ -101,19 +116,21 @@ adding the ``file`` option.
       .. c:autofunction:: example_function
          :file: example_file.c
 
-Structures, Unions, and Enumerations
-------------------------------------
+Structures, Classes, Unions, and Enumerations
+---------------------------------------------
 
 The :rst:dir:`c:autostruct`, :rst:dir:`c:autounion`, and :rst:dir:`c:autoenum`
-directives incorporate the documentation comments for the specified object in
-the specified file, with additional control over the structure or union members
-and enumeration constants to include.
+directives, their C++ domain counterparts, and the :rst:dir:`cpp:autoclass`
+directive incorporate the documentation comments for the specified object in the
+specified file, with additional control over the structure, class or union
+members and enumeration constants to include.
 
 The directives support all the same directive options as :rst:dir:`c:autodoc`,
 :rst:dir:`c:autovar`, :rst:dir:`c:autotype`, :rst:dir:`c:automacro`, and
 :rst:dir:`c:autofunction`, adding the ``members`` option.
 
 .. rst:directive:: .. c:autostruct:: name
+.. rst:directive:: .. cpp:autostruct:: name
 
    Incorporate the documentation comment for the structure ``name`` in the file
    ``file``, optionally including member documentation as specified by
@@ -148,7 +165,20 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
          :file: example_file.c
          :members: member_one, member_two
 
+.. rst:directive:: .. cpp:autoclass:: name
+
+   Same as :rst:dir:`cpp:autostruct` but for classes.
+
+   For example:
+
+   .. code-block:: rst
+
+      .. cpp:autoclass:: example_class
+         :file: example_file.cpp
+         :members: member_one, member_two
+
 .. rst:directive:: .. c:autounion:: name
+.. rst:directive:: .. cpp:autounion:: name
 
    Same as :rst:dir:`c:autostruct` but for unions.
 
@@ -159,6 +189,7 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
          :members: some_member
 
 .. rst:directive:: .. c:autoenum:: name
+.. rst:directive:: .. cpp:autoenum:: name
 
    Same as :rst:dir:`c:autostruct` but for enums. The enumeration constants are
    considered members and are included according to the ``members`` option.

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -1,12 +1,13 @@
 .. _extension:
 
-C Autodoc Extension
-===================
+Autodoc Extension
+=================
 
 Hawkmoth provides a Sphinx extension that adds :ref:`new directives
-<directives>` to the Sphinx :external+sphinx:ref:`C domain <c-domain>` to
-incorporate formatted C source code comments into a document. Hawkmoth is Sphinx
-:py:mod:`sphinx.ext.autodoc` for C.
+<directives>` to the Sphinx :external+sphinx:ref:`C <c-domain>` and
+:external+sphinx:ref:`C++ <cpp-domain>` domains to incorporate formatted C and
+C++ source code comments into a document. Hawkmoth is Sphinx
+:py:mod:`sphinx.ext.autodoc` for C/C++.
 
 For this to work, the documentation comments must of course be written in
 correct reStructuredText. See :ref:`documentation comment syntax <syntax>` for

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,14 +1,14 @@
-Hawkmoth - Sphinx Autodoc for C
-===============================
+Hawkmoth -- Sphinx Autodoc for C and C++
+========================================
 
-Hawkmoth is a minimalistic Sphinx_ :external+sphinx:ref:`C Domain <c-domain>`
-autodoc directive extension to incorporate formatted C source code comments
-written in reStructuredText_ into Sphinx based documentation. It uses Clang_
-Python Bindings for parsing, and generates C Domain directives for C API
-documentation, and more. In short, Hawkmoth is Sphinx Autodoc for C.
+Hawkmoth is a Sphinx_ extension to incorporate C and C++ source code comments
+formatted in reStructuredText_ into Sphinx based documentation. It uses Clang_
+Python Bindings for parsing, and generates :external+sphinx:ref:`C <c-domain>`
+and :external+sphinx:ref:`C++ <cpp-domain>` domain directives for C and C++
+documentation, respectively. In short, Hawkmoth is Sphinx Autodoc for C/C++.
 
-Hawkmoth aims to be a compelling alternative for documenting C projects using
-Sphinx, mainly through its simplicity of design, implementation and use.
+Hawkmoth aims to be a compelling alternative for documenting C and C++ projects
+using Sphinx, mainly through its simplicity of design, implementation and use.
 
 Please see the `Hawkmoth project GitHub page`_ (or README.rst in the source
 repository) for information on how to obtain, install, and contribute to

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -3,9 +3,9 @@
 Syntax
 ======
 
-For the :ref:`Hawkmoth autodoc directives <directives>` to work, the C source
-code must be documented using specific documentation comment style, and the
-comments must follow reStructuredText markup.
+For the :ref:`Hawkmoth autodoc directives <directives>` to work, the C or C++
+source code must be documented using specific documentation comment style, and
+the comments must follow reStructuredText markup.
 
 Optionally, the syntax may be :ref:`extended <extending-the-syntax>` to support
 e.g. Javadoc and Napoleon style comments.
@@ -16,7 +16,8 @@ and read on for documentation comment formatting details.
 Documentation Comments
 ----------------------
 
-Documentation comments are C language block comments that begin with ``/**``.
+Documentation comments are C/C++ language block comments that begin with
+``/**``.
 
 Because reStructuredText is sensitive about indentation, it's strongly
 recommended, even if not strictly required, to follow a uniform style for
@@ -38,12 +39,12 @@ One-line comments are fine too:
 
    /** The quick brown fox jumps over the lazy dog. */
 
-All documentation comments preceding C constructs are attached to them, and
-result in C Domain directives being added for them. This includes macros,
-functions, struct and union members, enumerations, etc.
+All documentation comments preceding C or C++ constructs are attached to them,
+and result in C or C++ Domain directives being added for them accordingly. This
+includes macros, functions, struct and union members, enumerations, etc.
 
 Documentation comments followed by comments (documentation or not) are included
-as generic documentation.
+as normal paragraphs in the order they appear.
 
 Tags
 ----
@@ -80,20 +81,33 @@ for :external+sphinx:py:mod:`sphinx.ext.napoleon` style comments.
 
 .. _Javadoc: https://www.oracle.com/technetwork/java/javase/documentation/javadoc-137458.html
 
-Cross-Referencing C Constructs
-------------------------------
+.. _cross-referencing:
 
-Use :external+sphinx:ref:`c-domain` roles for cross-referencing as follows:
+Cross-Referencing C and C++ Constructs
+--------------------------------------
 
-- ``:c:data:`name``` for variables.
+Under the hood, the :ref:`Hawkmoth directives <directives>` generate
+corresponding :external+sphinx:ref:`C <c-domain>` and :external+sphinx:ref:`C++
+<cpp-domain>` domain directives. For example, :rst:dir:`c:autovar` produces
+:external+sphinx:rst:dir:`c:var`. Use the Sphinx :external+sphinx:ref:`C Domain
+Roles <c-roles>` and :external+sphinx:ref:`C++ Domain Roles<cpp-roles>` for
+cross-referencing accordingly.
+
+For example:
+
+- ``:c:var:`name``` for variables.
 
 - ``:c:func:`name``` for functions and function-like macros.
 
-- ``:c:macro:`name``` for simple macros and enumeration constants.
-
-- ``:c:type:`name``` for structs, unions, enums, and typedefs.
+- ``:cpp:class:`name``` for classes.
 
 - ``:c:member:`name.membername``` for struct and union members.
+
+The C++ Domain does not have a ``cpp:macro`` directive, however, so all macros
+generate documentation using the C Domain :external+sphinx:rst:dir:`c:macro`
+directive. This also means macros have to be referenced using the
+:external+sphinx:rst:role:`c:macro` role, even when otherwise using C++ Domain
+directives.
 
 See the Sphinx :external+sphinx:ref:`basic-domain-markup` and generic
 :external+sphinx:ref:`xref-syntax` for further details on cross-referencing, and


### PR DESCRIPTION
Document the C++ support, and clean up and clarify documentation while at it.

I went through all the documentation and tweaked stuff all around the C++ changes. The first sentence in the `index.rst` was a mouthful even before the C++ stuff, so I simplified it a lot. On the other hand, I added more details and references here and there.

I opted to leave out any warnings about rudimentary C++ support for now. We can add that before the release depending on what we have.
