### PR TITLE
Doc alabaster theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -127,9 +127,15 @@ html_theme_options = {
 # defined by theme itself.  Builtin themes are using these templates by
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
-#
-# html_sidebars = {}
-
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',
+        'searchbox.html',
+        'donate.html',
+    ]
+}
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,7 +23,7 @@ extensions = [
 # -- Project information -----------------------------------------------------
 
 project = 'Hawkmoth'
-copyright = '2017-2019, Jani Nikula'
+copyright = '2017-2023, Jani Nikula and contributors'
 author = 'Jani Nikula'
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,11 +101,7 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-try:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-except ImportError:
-    sys.stderr.write('Warning: Read The Docs theme is not available.\n')
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,7 +107,13 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'description': 'Sphinx Autodoc for C',
+    'extra_nav_links': {
+        'GitHub': 'https://github.com/jnikula/hawkmoth',
+        'PyPI': 'https://pypi.org/project/hawkmoth',
+    }
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,6 +31,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   Introduction <self>
    installation
    extension
    directives


### PR DESCRIPTION
I was reminded by https://github.com/jnikula/hawkmoth/pull/137#issuecomment-1416878236 that I've got this branch where I'm experimenting with displaying documentation version more prominently and potentially adding multiple version support. I'm not quite there yet, but here's some early stuff. Not much point in hacking on the alabaster theme to display versions if we disagree on switching to it!
