### PR TITLE
update-examples: choose literalinclude language based on domain

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -244,7 +244,7 @@ Source
 ~~~~~~
 
 .. literalinclude:: ../test/examples/class.cpp
-   :language: C
+   :language: C++
    :caption: class.cpp
 
 Directive

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+import sys
 
 import testenv
 
@@ -52,14 +53,21 @@ def print_title(testcases):
 {get_title_underline(title)}
 ''')
 
-def print_source(input_filename):
+def print_source(testcases, input_filename):
+    domain = {testcase.options.get('domain') for testcase in testcases}
+    if len(domain) == 1:
+        language = 'C' if next(iter(domain)) == 'c' else 'C++'
+    else:
+        print(f'WARNING: {input_filename} used in multiple domains', file=sys.stderr)
+        language = 'C++'
+
     literal_include = f'../test/examples/{input_filename}'
 
     print(f'''Source
 ~~~~~~
 
 .. literalinclude:: {literal_include}
-   :language: C
+   :language: {language}
    :caption: {input_filename}
 ''')
 
@@ -122,6 +130,6 @@ if __name__ == '__main__':
 
     for source, testcases in sorted(get_examples().items(), key=examples_key):
         print_title(testcases)
-        print_source(source)
+        print_source(testcases, source)
         for testcase in sorted(testcases, key=testcase_key):
             print_example(testcase)


### PR DESCRIPTION
Use proper language for literalinclude based on the domain. Warn about the same file being used for multiple domains, although C++ should handle syntax highlighting for both just fine.