### PR TITLE
test: add our own src/ directory to the search path

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,6 +2,11 @@
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 
 import pytest
+import os
+import sys
+
+# Use 'our' version of the module.
+sys.path.insert(0, os.path.abspath('src'))
 
 # Enable introspection on assertions in testenv
 pytest.register_assert_rewrite('test.testenv')


### PR DESCRIPTION
So I _finally_ got around to try and package the newest version for Arch and discovered I couldn't run the tests with a simple `make test`.

No idea just yet if this will break the CI. Not sure why / how it's running in CI either, though I confess I haven't looked too hard into it. Either way, I am positive that `make test` was trying to run my old system installation of hawkmoth and this fixes it for me.

Not so related, and not sure if you had already commented on that, but `sphinx-testing` is now properly deprecated. I'm currently running an unmaintained version. We're probably on borrowed time here and we'll have to convert to the built in `sphinx.testing` soon :/