### PR TITLE
test: switch from sphinx-testing @with_app to sphinx.application.Sphinx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ pytest
 pytest-cov
 pytest-xdist
 sphinx
-sphinx-testing
 strictyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ dev =
     pytest
     pytest-cov
     pytest-xdist
-    sphinx-testing
     strictyaml
 
 [options.package_data]


### PR DESCRIPTION
The sphinx-testing package that provides the handy @with_app decorator has been deprecated in favour of sphinx.testing for years.

The sphinx.testing package provides a make_app pytest fixture to create a test app, but there are a number of downsides with it:

- You can only use make_app as a pytest fixture, and for test functions only. In our case, we'd have to route make_app as a parameter from test_directive_*() via testcase.run_test() all the way to the get_output() and get_expected() methods.

- There's no automatic temp directory creation and deletion for srcdir.

- There's no confdir parameter, so conf.py needs to be copied.

- It forces you to use the weird sphinx.testing custom path class.

I fail to see the upsides of jumping through hoops to use sphinx.testing for testing. Turns out it's actually much more clear to use sphinx.application.Sphinx directly. A lot of the "helpful" parts that make_app provides turn out to be something that we'd need to work around, and the Sphinx app lets us clean up things that were needed because of @with_app.

Use sphinx.application.Sphinx directly for Sphinx build.