### PR TITLE
build: add distclean target

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -43,4 +43,4 @@ test-upload:
 upload:
 	twine upload dist/*
 
-CLEAN := $(CLEAN) build dist hawkmoth.egg-info
+DISTCLEAN := $(DISTCLEAN) build dist hawkmoth.egg-info

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -22,4 +22,8 @@ quiet ?= $($1)
 clean:
 	$(call quiet,RM,CLEAN) -rf $(CLEAN)
 
+.PHONY: distclean
+distclean: clean
+	$(call quiet,RM,DISTCLEAN) -rf $(DISTCLEAN)
+
 .SUFFIXES:


### PR DESCRIPTION
'make clean' removes the editable install. Separate the removal of the build artefacts to 'make distclean'.