### PR TITLE
test: test the transformation extensions

### DIFF
--- a/test/conf.py
+++ b/test/conf.py
@@ -16,9 +16,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-from sphinx.ext.napoleon import docstring, Config
-from hawkmoth.util import doccompat
-
 # -- Project information -----------------------------------------------------
 
 project = 'Hawkmoth Test'
@@ -41,17 +38,10 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'hawkmoth'
+    'hawkmoth',
+    'hawkmoth.ext.javadoc',
+    'hawkmoth.ext.napoleon',
 ]
-
-def napoleon_transform(comment):
-    config = Config(napoleon_use_rtype=False)
-    return str(docstring.GoogleDocstring(comment, config))
-
-cautodoc_transformations = {
-    'napoleon': napoleon_transform,
-    'javadoc': doccompat.javadoc_liberal,
-}
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -4,11 +4,22 @@
 
 import os
 
+from sphinx.ext import napoleon
 import pytest
 
-from hawkmoth.parser import parse
 from hawkmoth import docstring
-from test import conf, testenv
+from hawkmoth.parser import parse
+from hawkmoth.util import doccompat
+from test import testenv
+
+def napoleon_transform(comment):
+    config = napoleon.Config(napoleon_use_rtype=False)
+    return str(napoleon.docstring.GoogleDocstring(comment, config))
+
+parser_transformations = {
+    'napoleon': napoleon_transform,
+    'javadoc': doccompat.javadoc_liberal,
+}
 
 def _transform(transform, lines):
     if transform:
@@ -76,7 +87,7 @@ class ParserTestcase(testenv.Testcase):
 
         tropt = directive_options.get('transform')
         if tropt is not None:
-            transform = conf.cautodoc_transformations[tropt]
+            transform = parser_transformations[tropt]
         else:
             transform = None
 


### PR DESCRIPTION
Use the built-in extensions to handle javadoc and napoleon when running tests via Sphinx, and use the conversions directly when running the parser tests. This extends test coverage on the recommended ways to handle syntax transformations.

Before:

Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
src/hawkmoth/ext/javadoc/__init__.py              12     12     0%
src/hawkmoth/ext/napoleon/__init__.py             11     11     0%
src/hawkmoth/ext/transformations/__init__.py      17      2    88%
------------------------------------------------------------------
TOTAL                                            850    103    88%

After:

Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
src/hawkmoth/ext/javadoc/__init__.py              12      0   100%
src/hawkmoth/ext/napoleon/__init__.py             11      0   100%
src/hawkmoth/ext/transformations/__init__.py      17      8    53%
------------------------------------------------------------------
TOTAL                                            850     86    90%