### PR TITLE
Autotext v2

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -203,3 +203,50 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
       .. c:autoenum:: example_enum
          :file: example_file.c
          :members: CONSTANT_ONE, CONSTANT_TWO
+
+Generic Documentation Comments
+------------------------------
+
+.. rst:directive:: .. c:autotext:: name
+.. rst:directive:: .. cpp:autotext:: name
+
+   Incorporate the text documentation comment identified by ``name`` in the file
+   ``file``. The ``file`` option is as in :rst:dir:`c:autovar`.
+
+   The ``name`` is derived from the first sentence of the comment, and may
+   contain whitespace. It starts from the first alphanumeric character,
+   inclusive, and extends to the next ``:``, ``.``, or newline, non-inclusive.
+
+   For example:
+
+   .. code-block:: c
+
+      /**
+       * This is the reference. This is not. It all becomes
+       * the documentation comment.
+       */
+
+   .. code-block:: rst
+
+      .. c:autotext:: This is the reference
+	 :file: example_file.c
+
+   Note that the above does not automatically create hyperlink targets that you
+   could reference from reStructuredText. However, reStructuredText hyperlink
+   targets work nicely as the reference name for the directive:
+
+   .. code-block:: c
+
+      /**
+       * .. _This is the reference:
+       *
+       * The actual documentation comment.
+       *
+       * You can use :ref:`This is the reference` to reference
+       * this comment in reStructuredText.
+       */
+
+   .. code-block:: rst
+
+      .. c:autotext:: This is the reference
+	 :file: example_file.c

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -312,6 +312,31 @@ Output
    :members:
 
 
+Generic Documentation Comments
+------------------------------
+
+Source
+~~~~~~
+
+.. literalinclude:: ../test/examples/autotext.c
+   :language: C
+   :caption: autotext.c
+
+Directive
+~~~~~~~~~
+
+.. code-block:: rest
+
+   .. c:autotext:: Hyperlink Target
+      :file: autotext.c
+
+Output
+~~~~~~
+
+.. c:autotext:: Hyperlink Target
+   :file: autotext.c
+
+
 Preprocessor
 ------------
 

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -191,6 +191,12 @@ class _AutoCompoundDirective(_AutoSymbolDirective):
 class CAutoDocDirective(_AutoDocDirective):
     _domain = 'c'
 
+class CAutoTextDirective(_AutoSymbolDirective):
+    # Allow spaces in the directive argument (the name)
+    final_argument_whitespace = True
+    _domain = 'c'
+    _docstring_types = [docstring.TextDocstring]
+
 class CAutoVarDirective(_AutoSymbolDirective):
     _domain = 'c'
     _docstring_types = [docstring.VarDocstring]
@@ -221,6 +227,12 @@ class CAutoEnumDirective(_AutoCompoundDirective):
 
 class CppAutoDocDirective(_AutoDocDirective):
     _domain = 'cpp'
+
+class CppAutoTextDirective(_AutoSymbolDirective):
+    # Allow spaces in the directive argument (the name)
+    final_argument_whitespace = True
+    _domain = 'cpp'
+    _docstring_types = [docstring.TextDocstring]
 
 class CppAutoVarDirective(_AutoSymbolDirective):
     _domain = 'cpp'
@@ -283,6 +295,7 @@ def setup(app):
     app.add_config_value('hawkmoth_transform_default', None, 'env', [str])
 
     app.add_directive_to_domain('c', 'autodoc', CAutoDocDirective)
+    app.add_directive_to_domain('c', 'autotext', CAutoTextDirective)
     app.add_directive_to_domain('c', 'autovar', CAutoVarDirective)
     app.add_directive_to_domain('c', 'autotype', CAutoTypeDirective)
     app.add_directive_to_domain('c', 'autostruct', CAutoStructDirective)
@@ -292,6 +305,7 @@ def setup(app):
     app.add_directive_to_domain('c', 'autofunction', CAutoFunctionDirective)
 
     app.add_directive_to_domain('cpp', 'autodoc', CppAutoDocDirective)
+    app.add_directive_to_domain('cpp', 'autotext', CppAutoTextDirective)
     app.add_directive_to_domain('cpp', 'autovar', CppAutoVarDirective)
     app.add_directive_to_domain('cpp', 'autotype', CppAutoTypeDirective)
     app.add_directive_to_domain('cpp', 'autostruct', CppAutoStructDirective)

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -198,6 +198,35 @@ class TextDocstring(Docstring):
     _indent = 0
     _fmt = '\n'
 
+    def get_name(self):
+        """Figure out a name for the text comment based on the comment contents.
+
+        The name is the sub-string starting from the first alphanumeric
+        character in the comment to the next :, ., or newline.
+
+        This sensibly covers cases like reStructuredText hyperlink targets::
+
+            .. _Foo Bar:
+
+        and section titles::
+
+            Foo Bar
+            =======
+
+        and just first sentences::
+
+            Foo Bar. Blah.
+
+        Not perfect, but good enough.
+        """
+        # If the parser passed in a name, use it (unlikely)
+        if self._name:
+            return self._name
+
+        mo = re.search(r'[\W_]*(?P<name>\w[^:.\n\r]*)', self._text)
+
+        return mo.group('name') if mo else None
+
 class VarDocstring(Docstring):
     _indent = 1
     _fmt = '\n.. {domain}:var:: {ttype}{type_spacer}{name}\n\n'

--- a/test/c/autotext.c
+++ b/test/c/autotext.c
@@ -1,0 +1,3 @@
+/**
+ * Just a random comment. Some more text.
+ */

--- a/test/c/autotext.rst
+++ b/test/c/autotext.rst
@@ -1,0 +1,3 @@
+
+Just a random comment. Some more text.
+

--- a/test/c/autotext.yaml
+++ b/test/c/autotext.yaml
@@ -1,0 +1,7 @@
+domain: c
+directive: autotext
+directive-arguments:
+  - Just a random comment
+directive-options:
+  file: autotext.c
+expected: autotext.rst

--- a/test/examples/autotext.c
+++ b/test/examples/autotext.c
@@ -1,0 +1,18 @@
+/**
+ * .. _Hyperlink Target:
+ *
+ * This is a generic documentation comment.
+ *
+ * Because generic documentation comments aren't attached to any symbols, the
+ * comment itself has to contain a name that can be referenced from the
+ * ``c:autotext`` or ``cpp:autotext`` directive.
+ *
+ * The name shall be from the first alphanumeric character in the comment,
+ * inclusive, to the next :, ., or newline, non-inclusive. This means
+ * reStructuredText hyperlink targets become reference names, like in this case,
+ * but it does not have to be a hyperlink target. It could just be the first
+ * sentence in the comment.
+ *
+ * No hyperlink targets are generated automatically. If you need to reference
+ * the comment from reStructuredText, you need to add one yourself.
+ */

--- a/test/examples/autotext.rst
+++ b/test/examples/autotext.rst
@@ -1,0 +1,18 @@
+
+.. _Hyperlink Target:
+
+This is a generic documentation comment.
+
+Because generic documentation comments aren't attached to any symbols, the
+comment itself has to contain a name that can be referenced from the
+``c:autotext`` or ``cpp:autotext`` directive.
+
+The name shall be from the first alphanumeric character in the comment,
+inclusive, to the next :, ., or newline, non-inclusive. This means
+reStructuredText hyperlink targets become reference names, like in this case,
+but it does not have to be a hyperlink target. It could just be the first
+sentence in the comment.
+
+No hyperlink targets are generated automatically. If you need to reference
+the comment from reStructuredText, you need to add one yourself.
+

--- a/test/examples/autotext.yaml
+++ b/test/examples/autotext.yaml
@@ -1,0 +1,9 @@
+domain: c
+directive: autotext
+directive-arguments:
+  - Hyperlink Target
+directive-options:
+  file: autotext.c
+example-priority: 75
+example-title: Generic Documentation Comments
+expected: autotext.rst

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -30,6 +30,7 @@ def _transform(transform, lines):
 def _filter_types(directive):
     types = {
         'autodoc': None,
+        'autotext': [docstring.TextDocstring],
         'autovar': [docstring.VarDocstring],
         'autotype': [docstring.TypeDocstring],
         'autostruct': [docstring.StructDocstring],
@@ -49,7 +50,7 @@ def _filter_names(directive, options):
     return options.get('directive-arguments')
 
 def _filter_members(directive, directive_options):
-    if directive in ['autodoc', 'autovar', 'autotype', 'automacro', 'autofunction']:
+    if directive in ['autodoc', 'autotext', 'autovar', 'autotype', 'automacro', 'autofunction']:
         return None
 
     members = directive_options.get('members')


### PR DESCRIPTION
I'm still pursuing #138. This improves and expands documentation and examples, and emphasizes that the "reference names" do not automatically become hyperlink targets.
