### PR TITLE
Process docstring naming

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -97,7 +97,7 @@ class _AutoBaseDirective(SphinxDirective):
                                     filter_names=self._get_names()):
             for docstr in docstrings.walk(filter_names=self._get_members()):
                 lineoffset = docstr.get_line() - 1
-                lines = docstr.get_docstring(transform=lambda lines: self.__transform(lines))
+                lines = docstr.get_docstring(process_docstring=lambda lines: self.__transform(lines))
                 for line in lines:
                     viewlist.append(line, filename, lineoffset)
                     lineoffset += 1

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -58,11 +58,6 @@ class _AutoBaseDirective(SphinxDirective):
 
         return clang_args
 
-    def __transform(self, lines):
-        transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
-
-        self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
-
     def __parse(self, filename):
         # Always pass `-xc++` to the compiler on 'cpp' domain as the first
         # option so that the user can override it.
@@ -90,14 +85,21 @@ class _AutoBaseDirective(SphinxDirective):
 
         return docstrings
 
+    def __process_docstring(self, lines):
+        transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
+
+        self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
+
     def __get_docstrings(self, viewlist, filename):
         root = self.__parse(filename)
+
+        process_docstring = lambda lines: self.__process_docstring(lines)
 
         for docstrings in root.walk(recurse=False, filter_types=self._docstring_types,
                                     filter_names=self._get_names()):
             for docstr in docstrings.walk(filter_names=self._get_members()):
                 lineoffset = docstr.get_line() - 1
-                lines = docstr.get_docstring(process_docstring=lambda lines: self.__transform(lines))
+                lines = docstr.get_docstring(process_docstring=process_docstring)
                 for line in lines:
                     viewlist.append(line, filename, lineoffset)
                     lineoffset += 1

--- a/src/hawkmoth/__main__.py
+++ b/src/hawkmoth/__main__.py
@@ -19,7 +19,7 @@ def filename(file):
         return file
     raise ValueError
 
-def transform(args, lines):
+def _process_docstring(args, lines):
     text = '\n'.join(lines)
     text = doccompat.convert(text, transform=args.compat)
     lines[:] = [line for line in text.splitlines()]
@@ -50,10 +50,12 @@ def main():
     comments, errors = parse(args.file, clang_args=args.clang)
     comments, errors = parse(args.file, domain=args.domain, clang_args=args.clang)
 
+    process_docstring = lambda lines: _process_docstring(args, lines)
+
     for comment in comments.walk():
         if args.verbose:
             print(f'# {comment.get_meta()}')
-        print('\n'.join(comment.get_docstring(process_docstring=lambda lines: transform(args, lines))))
+        print('\n'.join(comment.get_docstring(process_docstring=process_docstring)))
 
     for error in errors:
         print(f'{error.level.name}: {error.get_message()}', file=sys.stderr)

--- a/src/hawkmoth/__main__.py
+++ b/src/hawkmoth/__main__.py
@@ -53,7 +53,7 @@ def main():
     for comment in comments.walk():
         if args.verbose:
             print(f'# {comment.get_meta()}')
-        print('\n'.join(comment.get_docstring(transform=lambda lines: transform(args, lines))))
+        print('\n'.join(comment.get_docstring(process_docstring=lambda lines: transform(args, lines))))
 
     for error in errors:
         print(f'{error.level.name}: {error.get_message()}', file=sys.stderr)

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -159,7 +159,7 @@ class Docstring():
         """
         lines[:] = ['   ' * nest + line if line else '' for line in lines]
 
-    def get_docstring(self, transform=None):
+    def get_docstring(self, process_docstring=None):
         header_lines = self._get_header_lines()
         comment_lines = self._get_comment_lines()
 
@@ -168,8 +168,8 @@ class Docstring():
         # account.
         Docstring._remove_comment_markers(comment_lines)
 
-        if transform is not None:
-            transform(comment_lines)
+        if process_docstring is not None:
+            process_docstring(comment_lines)
 
         Docstring._nest(comment_lines, self._indent)
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -94,7 +94,7 @@ class ParserTestcase(testenv.Testcase):
         for docstrings in root.walk(recurse=False, filter_types=_filter_types(directive),
                                     filter_names=_filter_names(directive, options)):
             for docstr in docstrings.walk(filter_names=_filter_members(directive, directive_options)):  # noqa: E501
-                lines = docstr.get_docstring(transform=lambda lines: _transform(transform, lines))
+                lines = docstr.get_docstring(process_docstring=lambda lines: _transform(transform, lines))
                 docs_str += '\n'.join(lines) + '\n'
 
         for error in errors:

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -21,7 +21,7 @@ parser_transformations = {
     'javadoc': doccompat.javadoc_liberal,
 }
 
-def _transform(transform, lines):
+def _process_docstring(transform, lines):
     if transform:
         text = '\n'.join(lines)
         text = transform(text)
@@ -91,10 +91,12 @@ class ParserTestcase(testenv.Testcase):
         else:
             transform = None
 
+        process_docstring = lambda lines: _process_docstring(transform, lines)
+
         for docstrings in root.walk(recurse=False, filter_types=_filter_types(directive),
                                     filter_names=_filter_names(directive, options)):
             for docstr in docstrings.walk(filter_names=_filter_members(directive, directive_options)):  # noqa: E501
-                lines = docstr.get_docstring(process_docstring=lambda lines: _transform(transform, lines))
+                lines = docstr.get_docstring(process_docstring=process_docstring)
                 docs_str += '\n'.join(lines) + '\n'
 
         for error in errors:


### PR DESCRIPTION
Move towards "process docstring" naming instead of "transform", folloing the hawkmoth-process-docstring. No functional changes.