### PR TITLE
docstring: fix handling of empty documentation comments

### DIFF
--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -140,10 +140,10 @@ class Docstring():
         prefix_len = _get_prefix_len(lines[1:-1])
         lines[1:-1] = [line[prefix_len:] for line in lines[1:-1]]
 
-        while not lines[0] or lines[0].isspace():
+        while lines and (not lines[0] or lines[0].isspace()):
             del lines[0]
 
-        while not lines[-1] or lines[-1].isspace():
+        while lines and (not lines[-1] or lines[-1].isspace()):
             del lines[-1]
 
     @staticmethod

--- a/test/c/autosection-comment-strip.rst
+++ b/test/c/autosection-comment-strip.rst
@@ -1,0 +1,3 @@
+
+Top level comment.
+

--- a/test/c/autosection-comment-strip.yaml
+++ b/test/c/autosection-comment-strip.yaml
@@ -1,0 +1,7 @@
+domain: c
+directive: autosection
+directive-arguments:
+  - Top level comment
+directive-options:
+  file: comment-strip.c
+expected: autosection-comment-strip.rst

--- a/test/c/comment-strip.c
+++ b/test/c/comment-strip.c
@@ -107,3 +107,31 @@ int two_liner(int foo, int bar);
  	 */
 int two_liner_whitespace(int foo, int bar);
 
+/**/
+struct empty_comment_0 {
+	/** The embedding struct is not documented. */
+	int description;
+};
+
+/***/
+
+/***/
+struct empty_comment_1 {
+	/** The canonical empty documentation comment. */
+	int description;
+};
+
+/** Top level comment. */
+
+/** */
+struct empty_comment_2 {
+	/** Another empty documentation comment. */
+	int description;
+};
+
+/**
+ */
+struct empty_comment_3 {
+	/** Another empty documentation comment. */
+	int description;
+};

--- a/test/c/comment-strip.rst
+++ b/test/c/comment-strip.rst
@@ -109,3 +109,31 @@
 
    Two line comment with leading and trailing whitespace.
 
+
+
+.. c:struct:: empty_comment_1
+
+
+   .. c:member:: int description
+
+      The canonical empty documentation comment.
+
+
+Top level comment.
+
+
+.. c:struct:: empty_comment_2
+
+
+   .. c:member:: int description
+
+      Another empty documentation comment.
+
+
+.. c:struct:: empty_comment_3
+
+
+   .. c:member:: int description
+
+      Another empty documentation comment.
+

--- a/test/cpp/comment-strip.rst
+++ b/test/cpp/comment-strip.rst
@@ -109,3 +109,31 @@
 
    Two line comment with leading and trailing whitespace.
 
+
+
+.. cpp:struct:: empty_comment_1
+
+
+   .. cpp:member:: public int description
+
+      The canonical empty documentation comment.
+
+
+Top level comment.
+
+
+.. cpp:struct:: empty_comment_2
+
+
+   .. cpp:member:: public int description
+
+      Another empty documentation comment.
+
+
+.. cpp:struct:: empty_comment_3
+
+
+   .. cpp:member:: public int description
+
+      Another empty documentation comment.
+


### PR DESCRIPTION
Sometimes it's handy to add an empty documentation comment to generate documentation for a symbol without having to add some placeholder text. Or to include documentation for members/enumerations without documenting the struct/enum.

Currently, empty documentation comments lead to:

  File "docstring.py", line 143, in _remove_comment_markers
    while (not lines[0] or lines[0].isspace()):
               ~~~~~^^^
IndexError: list index out of range

Fix it and add some tests and documentation for it.