### PR TITLE
Optional file option

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -61,15 +61,20 @@ and :rst:dir:`cpp:autodoc`, adding the ``file`` option.
 .. rst:directive:: .. c:autovar:: name
 .. rst:directive:: .. cpp:autovar:: name
 
-   Incorporate the documentation comment for the variable ``name`` in the file
-   ``file``.
+   Incorporate the documentation comment for the variable ``name``.
+
+   If ``file`` is specified, look up ``name`` there, otherwise look up ``name``
+   in all previously parsed files in the current document.
 
    .. rst:directive:option:: file
       :type: text
 
-      The ``file`` option specifies to file to parse. The filename is
-      interpreted relative to the :data:`hawkmoth_root` configuration
-      option. (For the time being, this option is mandatory.)
+      The ``file`` option specifies the file to look up ``name`` in. This is
+      required if the file has not been parsed yet, and to disambiguate if
+      ``name`` is found in multiple files.
+
+      The filename is interpreted relative to the :data:`hawkmoth_root`
+      configuration option.
 
    For example:
 
@@ -77,6 +82,8 @@ and :rst:dir:`cpp:autodoc`, adding the ``file`` option.
 
       .. c:autovar:: example_variable
          :file: example_file.c
+
+      .. c:autovar:: another_variable
 
 .. rst:directive:: .. c:autotype:: name
 .. rst:directive:: .. cpp:autotype:: name
@@ -132,9 +139,12 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
 .. rst:directive:: .. c:autostruct:: name
 .. rst:directive:: .. cpp:autostruct:: name
 
-   Incorporate the documentation comment for the structure ``name`` in the file
-   ``file``, optionally including member documentation as specified by
-   ``members``.
+   Incorporate the documentation comment for the structure ``name``, optionally
+   including member documentation as specified by ``members``.
+
+   The ``file`` option is as in :rst:dir:`c:autovar`. If ``file`` is specified,
+   look up ``name`` there, otherwise look up ``name`` in all previously parsed
+   files in the current document.
 
    .. rst:directive:option:: members
       :type: text
@@ -158,11 +168,9 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
          :file: example_file.c
 
       .. c:autostruct:: example_struct
-         :file: example_file.c
          :members:
 
       .. c:autostruct:: example_struct
-         :file: example_file.c
          :members: member_one, member_two
 
 .. rst:directive:: .. cpp:autoclass:: name
@@ -201,7 +209,6 @@ The directives support all the same directive options as :rst:dir:`c:autodoc`,
          :members:
 
       .. c:autoenum:: example_enum
-         :file: example_file.c
          :members: CONSTANT_ONE, CONSTANT_TWO
 
 Generic Documentation Sections
@@ -214,12 +221,15 @@ specified file.
 .. rst:directive:: .. c:autosection:: name
 .. rst:directive:: .. cpp:autosection:: name
 
-   Incorporate the generic documentation comment identified by ``name`` in the
-   file ``file``. The ``file`` option is as in :rst:dir:`c:autovar`.
+   Incorporate the generic documentation comment identified by ``name``.
 
    The ``name`` is derived from the first sentence of the comment, and may
    contain whitespace. It starts from the first alphanumeric character,
    inclusive, and extends to the next ``:``, ``.``, or newline, non-inclusive.
+
+   The ``file`` option is as in :rst:dir:`c:autovar`. If ``file`` is specified,
+   look up ``name`` there, otherwise look up ``name`` in all previously parsed
+   files in the current document.
 
    For example:
 

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -72,7 +72,7 @@ class _AutoBaseDirective(SphinxDirective):
         key = (filename, tuple(clang_args))
 
         if key in parsed_files:
-            return parsed_files[key]
+            return
 
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
@@ -83,8 +83,6 @@ class _AutoBaseDirective(SphinxDirective):
         self.__display_parser_diagnostics(errors)
 
         parsed_files[key] = docstrings
-
-        return docstrings
 
     def __parsed_files(self, filter_filenames=None, filter_clang_args=None):
         parsed_files = self.env.temp_data.get('hawkmoth_parsed_files', {})

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -151,6 +151,9 @@ class _AutoBaseDirective(SphinxDirective):
             for filename in self._get_filenames():
                 self.__parse(filename)
 
+        if 'parse-only' in self.options:
+            return []
+
         result = ViewList()
 
         self.__get_docstrings(result)
@@ -168,6 +171,11 @@ class _AutoDocDirective(_AutoBaseDirective):
     # Allow passing a variable number of file patterns as arguments
     required_arguments = 1
     optional_arguments = 100   # arbitrary limit
+
+    option_spec = _AutoBaseDirective.option_spec.copy()
+    option_spec.update({
+        'parse-only': directives.flag,
+    })
 
     def _get_filenames(self):
         ret = []

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -160,6 +160,7 @@ class _AutoDocDirective(_AutoBaseDirective):
     optional_arguments = 100   # arbitrary limit
 
     def _get_filenames(self):
+        ret = []
         for pattern in self.arguments:
             filenames = glob.glob(os.path.join(self.env.config.hawkmoth_root, pattern))
             if len(filenames) == 0:
@@ -169,10 +170,12 @@ class _AutoDocDirective(_AutoBaseDirective):
 
             for filename in filenames:
                 if os.path.isfile(filename):
-                    yield os.path.abspath(filename)
+                    ret.append(os.path.abspath(filename))
                 else:
                     self.logger.warning(f'Path "{filename}" matching pattern "{pattern}" is not a file.',  # noqa: E501
                                         location=(self.env.docname, self.lineno))
+
+        return ret
 
 # Base class for named stuff
 class _AutoSymbolDirective(_AutoBaseDirective):

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -65,7 +65,7 @@ class _AutoBaseDirective(SphinxDirective):
         clang_args.extend(self.__get_clang_args())
 
         # Cached parse results per rst document
-        parsed_files = self.env.temp_data.setdefault('cautodoc_parsed_files', {})
+        parsed_files = self.env.temp_data.setdefault('hawkmoth_parsed_files', {})
 
         # The output depends on clang args
         key = (filename, tuple(clang_args))

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -86,6 +86,18 @@ class _AutoBaseDirective(SphinxDirective):
 
         return docstrings
 
+    def __parsed_files(self, filter_filenames=None, filter_clang_args=None):
+        parsed_files = self.env.temp_data.get('hawkmoth_parsed_files', {})
+
+        for root in parsed_files.values():
+            if filter_filenames is not None and root.get_filename() not in filter_filenames:
+                continue
+
+            if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
+                continue
+
+            yield root
+
     def __process_docstring(self, lines):
         transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
 
@@ -109,9 +121,8 @@ class _AutoBaseDirective(SphinxDirective):
 
     def __get_docstrings(self, viewlist):
         num_matches = 0
-        for filename in self._get_filenames():
-            # These are all pre-parsed results now
-            root = self.__parse(filename)
+        for root in self.__parsed_files(filter_filenames=self._get_filenames(),
+                                        filter_clang_args=[self.__get_clang_args()]):
             num_matches += self.__get_docstrings_for_root(viewlist, root)
 
         if num_matches == 0:

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -147,8 +147,9 @@ class _AutoBaseDirective(SphinxDirective):
         raise NotImplementedError(self.__class__.__name__ + '._get_filenames')
 
     def run(self):
-        for filename in self._get_filenames():
-            self.__parse(filename)
+        if self._get_filenames():
+            for filename in self._get_filenames():
+                self.__parse(filename)
 
         result = ViewList()
 
@@ -200,12 +201,8 @@ class _AutoSymbolDirective(_AutoBaseDirective):
 
     def _get_filenames(self):
         filename = self.options.get('file')
-
-        # Note: For the time being the file option is mandatory (sic).
         if not filename:
-            self.logger.warning(':file: option missing.',
-                                location=(self.env.docname, self.lineno))
-            return []
+            return None
 
         return [os.path.abspath(os.path.join(self.env.config.hawkmoth_root, filename))]
 

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -52,17 +52,18 @@ class _AutoBaseDirective(SphinxDirective):
                             location=(self.env.docname, self.lineno))
 
     def __get_clang_args(self):
-        clang_args = self.env.config.hawkmoth_clang.copy()
+        # Always pass `-xc++` to the compiler on 'cpp' domain as the first
+        # option so that the user can override it.
+        clang_args = ['-xc++'] if self._domain == 'cpp' else []
+
+        clang_args.extend(self.env.config.hawkmoth_clang.copy())
 
         clang_args.extend(self.options.get('clang', []))
 
         return clang_args
 
     def __parse(self, filename):
-        # Always pass `-xc++` to the compiler on 'cpp' domain as the first
-        # option so that the user can override it.
-        clang_args = ['-xc++'] if self._domain == 'cpp' else []
-        clang_args.extend(self.__get_clang_args())
+        clang_args = self.__get_clang_args()
 
         # Cached parse results per rst document
         parsed_files = self.env.temp_data.setdefault('hawkmoth_parsed_files', {})

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -123,6 +123,10 @@ class _AutoBaseDirective(SphinxDirective):
                 # autodoc
                 self.logger.warning('No documented symbols were found.',
                                     location=(self.env.docname, self.lineno))
+        elif num_matches > 1 and self._get_names():
+            args = ' '.join(self.arguments)
+            self.logger.warning(f'"{self.name}:: {args}" matches {num_matches} documented symbols.',
+                                location=(self.env.docname, self.lineno))
 
     def _get_names(self):
         return None

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -194,6 +194,21 @@ class Docstring():
     def get_line(self):
         return self._meta['line']
 
+class RootDocstring(Docstring):
+    def __init__(self, filename=None, domain='c', clang_args=None):
+        super().__init__(domain=domain)
+        self._filename = filename
+        self._clang_args = clang_args
+
+    def get_filename(self):
+        return self._filename
+
+    def get_clang_args(self):
+        return self._clang_args
+
+    def get_domain(self):
+        return self._domain
+
 class TextDocstring(Docstring):
     _indent = 0
     _fmt = '\n'

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -742,7 +742,8 @@ def _parse_undocumented_block(domain, comments, errors, cursor, nest):
 # Parse a file and return a tree of docstring.Docstring objects.
 def parse(filename, domain=None, clang_args=None):
     # Empty root comment with just children
-    result = docstring.Docstring()
+    result = docstring.RootDocstring(filename=filename, domain=domain,
+                                     clang_args=clang_args)
     errors = []
     index = Index.create()
 


### PR DESCRIPTION
First stab at better separation of parsing and incorporating documentation, and making the file option actually optional.

With this, you can do

```
.. c:autofunction:: foo
   :file: baz.c

.. c:autofunction:: bar
```

And the later directives will match symbols against all previously parsed files in the rst document.

Additionally, there's:

```
.. c:autodoc:: bar.c
   :parse-only:

.. c:autofunction:: bar
```

And it works the same way, but has a more explicit feeling to it.

This is the first step; later I imagine also being able to parse files *before* any rst documents are read, and the symbols are searched against all of them.

