### PR TITLE
Optional file option prep work

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -72,7 +72,7 @@ class _AutoBaseDirective(SphinxDirective):
         key = (filename, tuple(clang_args))
 
         if key in parsed_files:
-            return parsed_files[key]
+            return
 
         # Tell Sphinx about the dependency
         self.env.note_dependency(filename)
@@ -83,8 +83,6 @@ class _AutoBaseDirective(SphinxDirective):
         self.__display_parser_diagnostics(errors)
 
         parsed_files[key] = docstrings
-
-        return docstrings
 
     def __parsed_files(self, filter_filenames=None, filter_clang_args=None):
         parsed_files = self.env.temp_data.get('hawkmoth_parsed_files', {})

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -65,7 +65,7 @@ class _AutoBaseDirective(SphinxDirective):
         clang_args.extend(self.__get_clang_args())
 
         # Cached parse results per rst document
-        parsed_files = self.env.temp_data.setdefault('cautodoc_parsed_files', {})
+        parsed_files = self.env.temp_data.setdefault('hawkmoth_parsed_files', {})
 
         # The output depends on clang args
         key = (filename, tuple(clang_args))

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -86,6 +86,18 @@ class _AutoBaseDirective(SphinxDirective):
 
         return docstrings
 
+    def __parsed_files(self, filter_filenames=None, filter_clang_args=None):
+        parsed_files = self.env.temp_data.get('hawkmoth_parsed_files', {})
+
+        for root in parsed_files.values():
+            if filter_filenames is not None and root.get_filename() not in filter_filenames:
+                continue
+
+            if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
+                continue
+
+            yield root
+
     def __process_docstring(self, lines):
         transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
 
@@ -109,9 +121,8 @@ class _AutoBaseDirective(SphinxDirective):
 
     def __get_docstrings(self, viewlist):
         num_matches = 0
-        for filename in self._get_filenames():
-            # These are all pre-parsed results now
-            root = self.__parse(filename)
+        for root in self.__parsed_files(filter_filenames=list(self._get_filenames()),
+                                        filter_clang_args=[self.__get_clang_args()]):
             num_matches += self.__get_docstrings_for_root(viewlist, root)
 
         if num_matches == 0:

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -52,17 +52,18 @@ class _AutoBaseDirective(SphinxDirective):
                             location=(self.env.docname, self.lineno))
 
     def __get_clang_args(self):
-        clang_args = self.env.config.hawkmoth_clang.copy()
+        # Always pass `-xc++` to the compiler on 'cpp' domain as the first
+        # option so that the user can override it.
+        clang_args = ['-xc++'] if self._domain == 'cpp' else []
+
+        clang_args.extend(self.env.config.hawkmoth_clang.copy())
 
         clang_args.extend(self.options.get('clang', []))
 
         return clang_args
 
     def __parse(self, filename):
-        # Always pass `-xc++` to the compiler on 'cpp' domain as the first
-        # option so that the user can override it.
-        clang_args = ['-xc++'] if self._domain == 'cpp' else []
-        clang_args.extend(self.__get_clang_args())
+        clang_args = self.__get_clang_args()
 
         # Cached parse results per rst document
         parsed_files = self.env.temp_data.setdefault('hawkmoth_parsed_files', {})

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -123,6 +123,10 @@ class _AutoBaseDirective(SphinxDirective):
                 # autodoc
                 self.logger.warning('No documented symbols were found.',
                                     location=(self.env.docname, self.lineno))
+        elif num_matches > 1 and self._get_names():
+            args = ' '.join(self.arguments)
+            self.logger.warning(f'"{self.name}:: {args}" matches {num_matches} documented symbols.',
+                                location=(self.env.docname, self.lineno))
 
     def _get_names(self):
         return None

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -194,6 +194,21 @@ class Docstring():
     def get_line(self):
         return self._meta['line']
 
+class RootDocstring(Docstring):
+    def __init__(self, filename=None, domain='c', clang_args=None):
+        super().__init__(domain=domain)
+        self._filename = filename
+        self._clang_args = clang_args
+
+    def get_filename(self):
+        return self._filename
+
+    def get_clang_args(self):
+        return self._clang_args
+
+    def get_domain(self):
+        return self._domain
+
 class TextDocstring(Docstring):
     _indent = 0
     _fmt = '\n'

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -742,7 +742,8 @@ def _parse_undocumented_block(domain, comments, errors, cursor, nest):
 # Parse a file and return a tree of docstring.Docstring objects.
 def parse(filename, domain=None, clang_args=None):
     # Empty root comment with just children
-    result = docstring.Docstring()
+    result = docstring.RootDocstring(filename=filename, domain=domain,
+                                     clang_args=clang_args)
     errors = []
     index = Index.create()
 


### PR DESCRIPTION
This is all the prep work from #168 without the actual functional change of making the `:file:` option optional. I also dropped the generator removal change, and used `list()` around the caller instead.

I figured this one doesn't really need specific tests, while I figure out how to test the rest of the changes.
