### PR TITLE
Test multiple directives prep work

### DIFF
--- a/test/c/autoenum.yaml
+++ b/test/c/autoenum.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autoenum
-directive-arguments:
+directives:
+- domain: c
+  directive: autoenum
+  arguments:
   - foo
-directive-options:
-  file: enum.c
-  members:
+  options:
+    file: enum.c
+    members:
     - bar
 expected: autoenum.rst

--- a/test/c/autosection-comment-strip.yaml
+++ b/test/c/autosection-comment-strip.yaml
@@ -1,7 +1,8 @@
-domain: c
-directive: autosection
-directive-arguments:
+directives:
+- domain: c
+  directive: autosection
+  arguments:
   - Top level comment
-directive-options:
-  file: comment-strip.c
+  options:
+    file: comment-strip.c
 expected: autosection-comment-strip.rst

--- a/test/c/autosection.yaml
+++ b/test/c/autosection.yaml
@@ -1,7 +1,8 @@
-domain: c
-directive: autosection
-directive-arguments:
+directives:
+- domain: c
+  directive: autosection
+  arguments:
   - Just a random comment
-directive-options:
-  file: autosection.c
+  options:
+    file: autosection.c
 expected: autosection.rst

--- a/test/c/autostruct-no-members.yaml
+++ b/test/c/autostruct-no-members.yaml
@@ -1,7 +1,8 @@
-domain: c
-directive: autostruct
-directive-arguments:
+directives:
+- domain: c
+  directive: autostruct
+  arguments:
   - sample_struct
-directive-options:
-  file: struct.c
+  options:
+    file: struct.c
 expected: autostruct-no-members.rst

--- a/test/c/autostruct.rst
+++ b/test/c/autostruct.rst
@@ -23,3 +23,33 @@
       :param foo: the foo
       :param bar: the bar
 
+
+.. c:struct:: foo_struct
+
+   Named struct.
+
+
+   .. c:struct:: @anonymous_a63d10331be1a527625db63b8ace540f
+
+      Anonymous sub-struct.
+
+
+      .. c:member:: int foo_member
+
+         Member foo.
+
+
+   .. c:union:: @anonymous_69382278a84175c1cbff40d522114b38
+
+      Anonymous sub-union.
+
+
+      .. c:member:: int bar_member_1
+
+         Member bar 1.
+
+
+      .. c:member:: int bar_member_2
+
+         Member bar 2.
+

--- a/test/c/autostruct.yaml
+++ b/test/c/autostruct.yaml
@@ -9,4 +9,11 @@ directives:
     - array_member
     - function_pointer_member
     - other_function_pointer_member
+- domain: c
+  directive: autostruct
+  arguments:
+  - foo_struct
+  options:
+    file: struct.c
+    members:
 expected: autostruct.rst

--- a/test/c/autostruct.yaml
+++ b/test/c/autostruct.yaml
@@ -1,10 +1,11 @@
-domain: c
-directive: autostruct
-directive-arguments:
+directives:
+- domain: c
+  directive: autostruct
+  arguments:
   - sample_struct
-directive-options:
-  file: struct.c
-  members:
+  options:
+    file: struct.c
+    members:
     - array_member
     - function_pointer_member
     - other_function_pointer_member

--- a/test/c/autovariable-fnptr-array.yaml
+++ b/test/c/autovariable-fnptr-array.yaml
@@ -1,7 +1,8 @@
-domain: c
-directive: autovar
-directive-arguments:
+directives:
+- domain: c
+  directive: autovar
+  arguments:
   - function_pointer_array
-directive-options:
-  file: variable.c
+  options:
+    file: variable.c
 expected: autovariable-fnptr-array.rst

--- a/test/c/clang-diagnostics.yaml
+++ b/test/c/clang-diagnostics.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - clang-diagnostics.c
 errors: clang-diagnostics.stderr
 expected: clang-diagnostics.rst

--- a/test/c/comment-strip.yaml
+++ b/test/c/comment-strip.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - comment-strip.c
 expected: comment-strip.rst

--- a/test/c/composition.yaml
+++ b/test/c/composition.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - composition.c
 expected: composition.rst

--- a/test/c/doc.yaml
+++ b/test/c/doc.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - doc.c
 expected: doc.rst

--- a/test/c/enum.yaml
+++ b/test/c/enum.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - enum.c
 expected: enum.rst

--- a/test/c/function-like-macro.yaml
+++ b/test/c/function-like-macro.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - function-like-macro.c
 expected: function-like-macro.rst

--- a/test/c/function.yaml
+++ b/test/c/function.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - function.c
 expected: function.rst

--- a/test/c/meta-expected-failure.yaml
+++ b/test/c/meta-expected-failure.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - meta-expected-failure.c
 expected-failure: true
 expected: meta-expected-failure.rst

--- a/test/c/restrict.yaml
+++ b/test/c/restrict.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - restrict.c
 expected: restrict.rst

--- a/test/c/simple-macro.yaml
+++ b/test/c/simple-macro.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - simple-macro.c
 expected: simple-macro.rst

--- a/test/c/struct.yaml
+++ b/test/c/struct.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - struct.c
 expected: struct.rst

--- a/test/c/typedef-enum.yaml
+++ b/test/c/typedef-enum.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - typedef-enum.c
 expected: typedef-enum.rst

--- a/test/c/typedef-struct.yaml
+++ b/test/c/typedef-struct.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - typedef-struct.c
 expected: typedef-struct.rst

--- a/test/c/typedef.yaml
+++ b/test/c/typedef.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - typedef.c
 expected: typedef.rst

--- a/test/c/union.yaml
+++ b/test/c/union.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - union.c
 expected: union.rst

--- a/test/c/variable.yaml
+++ b/test/c/variable.yaml
@@ -1,5 +1,6 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - variable.c
 expected: variable.rst

--- a/test/cpp/autoclass-no-members.yaml
+++ b/test/cpp/autoclass-no-members.yaml
@@ -1,7 +1,8 @@
-domain: cpp
-directive: autoclass
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autoclass
+  arguments:
   - foo
-directive-options:
-  file: class.cpp
+  options:
+    file: class.cpp
 expected: autoclass-no-members.rst

--- a/test/cpp/autoclass.yaml
+++ b/test/cpp/autoclass.yaml
@@ -1,10 +1,11 @@
-domain: cpp
-directive: autoclass
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autoclass
+  arguments:
   - foo
-directive-options:
-  file: class.cpp
-  members:
+  options:
+    file: class.cpp
+    members:
     - mutable_member
     - virtual_method
     - const_method_to_const

--- a/test/cpp/autoenum.yaml
+++ b/test/cpp/autoenum.yaml
@@ -1,9 +1,10 @@
-domain: cpp
-directive: autoenum
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autoenum
+  arguments:
   - foo
-directive-options:
-  file: ../c/enum.c
-  members:
+  options:
+    file: ../c/enum.c
+    members:
     - bar
 expected: autoenum.rst

--- a/test/cpp/autostruct-no-members.yaml
+++ b/test/cpp/autostruct-no-members.yaml
@@ -1,7 +1,8 @@
-domain: cpp
-directive: autostruct
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autostruct
+  arguments:
   - sample_struct
-directive-options:
-  file: ../c/struct.c
+  options:
+    file: ../c/struct.c
 expected: autostruct-no-members.rst

--- a/test/cpp/autostruct.yaml
+++ b/test/cpp/autostruct.yaml
@@ -1,10 +1,11 @@
-domain: cpp
-directive: autostruct
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autostruct
+  arguments:
   - sample_struct
-directive-options:
-  file: ../c/struct.c
-  members:
+  options:
+    file: ../c/struct.c
+    members:
     - array_member
     - function_pointer_member
     - other_function_pointer_member

--- a/test/cpp/autovariable-fnptr-array.yaml
+++ b/test/cpp/autovariable-fnptr-array.yaml
@@ -1,7 +1,8 @@
-domain: cpp
-directive: autovar
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autovar
+  arguments:
   - function_pointer_array
-directive-options:
-  file: ../c/variable.c
+  options:
+    file: ../c/variable.c
 expected: autovariable-fnptr-array.rst

--- a/test/cpp/clang-diagnostics.yaml
+++ b/test/cpp/clang-diagnostics.yaml
@@ -1,6 +1,7 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/clang-diagnostics.c
 errors: clang-diagnostics.stderr
 expected: clang-diagnostics.rst

--- a/test/cpp/class.yaml
+++ b/test/cpp/class.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - class.cpp
 expected: class.rst

--- a/test/cpp/comment-strip.yaml
+++ b/test/cpp/comment-strip.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/comment-strip.c
 expected: comment-strip.rst

--- a/test/cpp/composition.yaml
+++ b/test/cpp/composition.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/composition.c
 expected: composition.rst

--- a/test/cpp/doc.yaml
+++ b/test/cpp/doc.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/doc.c
 expected: doc.rst

--- a/test/cpp/enum-class.yaml
+++ b/test/cpp/enum-class.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - enum-class.cpp
 expected: enum-class.rst

--- a/test/cpp/enum.yaml
+++ b/test/cpp/enum.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/enum.c
 expected: enum.rst

--- a/test/cpp/function-like-macro.yaml
+++ b/test/cpp/function-like-macro.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/function-like-macro.c
 expected: function-like-macro.rst

--- a/test/cpp/function.yaml
+++ b/test/cpp/function.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/function.c
 expected: function.rst

--- a/test/cpp/meta-expected-failure.yaml
+++ b/test/cpp/meta-expected-failure.yaml
@@ -1,6 +1,7 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/meta-expected-failure.c
 expected-failure: true
 expected: meta-expected-failure.rst

--- a/test/cpp/mixed-linkage.yaml
+++ b/test/cpp/mixed-linkage.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - mixed-linkage.cpp
 expected: mixed-linkage.rst

--- a/test/cpp/simple-macro.yaml
+++ b/test/cpp/simple-macro.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/simple-macro.c
 expected: simple-macro.rst

--- a/test/cpp/struct-class.yaml
+++ b/test/cpp/struct-class.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - struct-class.cpp
 expected: struct-class.rst

--- a/test/cpp/struct.yaml
+++ b/test/cpp/struct.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/struct.c
 expected: struct.rst

--- a/test/cpp/template.yaml
+++ b/test/cpp/template.yaml
@@ -1,8 +1,9 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - template.cpp
-directive-options:
-  clang:
+  options:
+    clang:
     - --std=c++17
 expected: template.rst

--- a/test/cpp/typedef-enum.yaml
+++ b/test/cpp/typedef-enum.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/typedef-enum.c
 expected: typedef-enum.rst

--- a/test/cpp/typedef-struct.yaml
+++ b/test/cpp/typedef-struct.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/typedef-struct.c
 expected: typedef-struct.rst

--- a/test/cpp/typedef.yaml
+++ b/test/cpp/typedef.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/typedef.c
 expected: typedef.rst

--- a/test/cpp/union.yaml
+++ b/test/cpp/union.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/union.c
 expected: union.rst

--- a/test/cpp/variable.yaml
+++ b/test/cpp/variable.yaml
@@ -1,5 +1,6 @@
-domain: cpp
-directive: autodoc
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
   - ../c/variable.c
 expected: variable.rst

--- a/test/cpp/wrong-syntax.yaml
+++ b/test/cpp/wrong-syntax.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - wrong-syntax.h
 errors: wrong-syntax.stderr
 expected: wrong-syntax.rst

--- a/test/examples/autoclass.yaml
+++ b/test/examples/autoclass.yaml
@@ -1,10 +1,11 @@
-domain: cpp
-directive: autoclass
-directive-arguments:
+directives:
+- domain: cpp
+  directive: autoclass
+  arguments:
   - Circle
-directive-options:
-  file: class.cpp
-  members:
+  options:
+    file: class.cpp
+    members:
 example-title: Class
 example-priority: 55
 expected: autoclass.rst

--- a/test/examples/autodoc.yaml
+++ b/test/examples/autodoc.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - overview.c
 example-title: Overview
 example-priority: 1

--- a/test/examples/autofunction.yaml
+++ b/test/examples/autofunction.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autofunction
-directive-arguments:
+directives:
+- domain: c
+  directive: autofunction
+  arguments:
   - frob
-directive-options:
-  file: function.c
+  options:
+    file: function.c
 example-use-namespace: yes
 example-title: Function
 example-priority: 41

--- a/test/examples/automacro.yaml
+++ b/test/examples/automacro.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: automacro
-directive-arguments:
+directives:
+- domain: c
+  directive: automacro
+  arguments:
   - DIE
-directive-options:
-  file: macro.c
+  options:
+    file: macro.c
 example-use-namespace: yes
 example-title: Macro
 example-priority: 31

--- a/test/examples/autosection.yaml
+++ b/test/examples/autosection.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autosection
-directive-arguments:
+directives:
+- domain: c
+  directive: autosection
+  arguments:
   - Hyperlink Target
-directive-options:
-  file: autosection.c
-example-priority: 75
+  options:
+    file: autosection.c
 example-title: Generic Documentation Section
+example-priority: 75
 expected: autosection.rst

--- a/test/examples/autostruct.yaml
+++ b/test/examples/autostruct.yaml
@@ -1,10 +1,11 @@
-domain: c
-directive: autostruct
-directive-arguments:
+directives:
+- domain: c
+  directive: autostruct
+  arguments:
   - list
-directive-options:
-  file: struct.c
-  members:
+  options:
+    file: struct.c
+    members:
 example-use-namespace: yes
 example-title: Struct
 example-priority: 51

--- a/test/examples/autounion.yaml
+++ b/test/examples/autounion.yaml
@@ -1,10 +1,11 @@
-domain: c
-directive: autounion
-directive-arguments:
+directives:
+- domain: c
+  directive: autounion
+  arguments:
   - onion
-directive-options:
-  file: union.c
-  members:
+  options:
+    file: union.c
+    members:
 example-title: Union
 example-priority: 60
 expected: autounion.rst

--- a/test/examples/autovar.yaml
+++ b/test/examples/autovar.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autovar
-directive-arguments:
+directives:
+- domain: c
+  directive: autovar
+  arguments:
   - meaning_of_life
-directive-options:
-  file: variable.c
+  options:
+    file: variable.c
 example-use-namespace: yes
 example-title: Variable
 example-priority: 11

--- a/test/examples/enum.yaml
+++ b/test/examples/enum.yaml
@@ -1,10 +1,11 @@
-domain: c
-directive: autoenum
-directive-arguments:
+directives:
+- domain: c
+  directive: autoenum
+  arguments:
   - mode
-directive-options:
-  file: enum.c
-  members:
+  options:
+    file: enum.c
+    members:
 example-title: Enum
 example-priority: 70
 expected: enum.rst

--- a/test/examples/function.yaml
+++ b/test/examples/function.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - function.c
 example-title: Function
 example-priority: 40

--- a/test/examples/javadoc.yaml
+++ b/test/examples/javadoc.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - javadoc.c
-directive-options:
-  transform: javadoc
+  options:
+    transform: javadoc
 example-title: Javadoc-style comments
 example-priority: 95
 expected: javadoc.rst

--- a/test/examples/macro.yaml
+++ b/test/examples/macro.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - macro.c
 example-title: Macro
 example-priority: 30

--- a/test/examples/napoleon.yaml
+++ b/test/examples/napoleon.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - napoleon.c
-directive-options:
-  transform: napoleon
+  options:
+    transform: napoleon
 example-title: Napoleon-style comments
 example-priority: 90
 expected: napoleon.rst

--- a/test/examples/preprocessor.yaml
+++ b/test/examples/preprocessor.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - preprocessor.c
-directive-options:
-  clang:
+  options:
+    clang:
     - -DDEEP_THOUGHT
 example-title: Preprocessor
 example-priority: 80

--- a/test/examples/struct.yaml
+++ b/test/examples/struct.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - struct.c
 example-title: Struct
 example-priority: 50

--- a/test/examples/typedef.yaml
+++ b/test/examples/typedef.yaml
@@ -1,9 +1,10 @@
-domain: c
-directive: autotype
-directive-arguments:
+directives:
+- domain: c
+  directive: autotype
+  arguments:
   - list_data_t
-directive-options:
-  file: typedef.c
+  options:
+    file: typedef.c
 example-title: Typedef
 example-priority: 20
 expected: typedef.rst

--- a/test/examples/variable.yaml
+++ b/test/examples/variable.yaml
@@ -1,6 +1,7 @@
-domain: c
-directive: autodoc
-directive-arguments:
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
   - variable.c
 example-title: Variable
 example-priority: 10

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -52,7 +52,9 @@ class ExtensionTestcase(testenv.Testcase):
             return self._sphinx_build(srcdir)
 
     def get_output(self):
-        return self._sphinx_build_str(self.get_directive_string())
+        input_str = ''.join([d.get_directive_string() for d in self.directives])
+
+        return self._sphinx_build_str(input_str)
 
     def get_expected(self):
         return self._sphinx_build_file(self.get_expected_filename())

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -90,17 +90,11 @@ class Testcase:
 
         return os.path.join(os.path.dirname(self.filename), relative)
 
-    def get_input_filename(self):
-        return self.directives[0].get_input_filename()
-
     def get_expected_filename(self):
         return self.get_relative_filename(self.options.get('expected'))
 
     def get_stderr_filename(self):
         return self.get_relative_filename(self.options.get('errors'))
-
-    def get_directive_string(self):
-        return self.directives[0].get_directive_string()
 
     def run_test(self):
         if self.options.get('expected-failure'):

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -48,7 +48,7 @@ def print_title(testcases):
 ''')
 
 def print_source(testcases, input_filename):
-    domain = {testcase.options.get('domain') for testcase in testcases}
+    domain = {testcase.directives[0].domain for testcase in testcases}
     if len(domain) == 1:
         language = 'C' if next(iter(domain)) == 'c' else 'C++'
     else:
@@ -67,7 +67,7 @@ def print_source(testcases, input_filename):
 
 def print_example(testcase):
     options = testcase.options
-    domain = options.get('domain')
+    domain = testcase.directives[0].domain
 
     if options.get('example-use-namespace'):
         # Generate namespace from relative path to YAML without extension
@@ -82,7 +82,7 @@ def print_example(testcase):
         namespace_push = ''
         namespace_pop = ''
 
-    directive_str = testcase.get_directive_string()
+    directive_str = testcase.directives[0].get_directive_string()
 
     print(f'''Directive
 ~~~~~~~~~
@@ -110,7 +110,11 @@ def get_examples():
 
     for f in testenv.get_testcase_filenames(os.path.join(testenv.testdir, 'examples')):
         testcase = ExampleTestcase(f)
-        input_filename = os.path.basename(testcase.get_input_filename())
+
+        if len(testcase.directives) != 1:
+            print(f'WARNING: {f} uses multiple directives', file=sys.stderr)
+
+        input_filename = os.path.basename(testcase.directives[0].get_input_filename())
 
         if input_filename in examples:
             examples[input_filename].append(testcase)


### PR DESCRIPTION
To properly test directives where the source file is not specified, we'll need testcases to support multiple directives. This is prep work for that, converting the schema to support a list of directives.
