### PR TITLE
test: fix stale reference to autotext

### DIFF
--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -50,7 +50,7 @@ def _filter_names(directive):
     return directive.arguments
 
 def _filter_members(directive):
-    if directive.directive in ['autodoc', 'autotext', 'autovar', 'autotype',
+    if directive.directive in ['autodoc', 'autosection', 'autovar', 'autotype',
                                'automacro', 'autofunction']:
         return None
 


### PR DESCRIPTION
"autotext" was renamed to "autosection", but one "autotext" slipped through.