### PR TITLE
Bool conversion

### DIFF
--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -401,6 +401,9 @@ def _get_scopedenum_type(cursor):
             return f': {cursor.enum_type.spelling}'
     return None
 
+def _normalize_type(type_string):
+    return 'bool' if type_string == '_Bool' else type_string
+
 def _var_type_fixup(cursor, domain):
     """Fix non trivial variable and argument types.
 
@@ -455,7 +458,7 @@ def _var_type_fixup(cursor, domain):
         if len(args) == 0:
             args.append('void')
 
-        ret_type = cursor_type.get_result().spelling
+        ret_type = _normalize_type(cursor_type.get_result().spelling)
 
         name = f'''{pad(ret_type)}({pad(stars_and_quals)}{cursor.spelling}{dims})({', '.join(args)})'''  # noqa: E501
     else:
@@ -470,6 +473,9 @@ def _var_type_fixup(cursor, domain):
             type_elem.append(stars_and_quals)
 
         name = cursor.spelling + dims
+
+    # Convert _Bool to bool
+    type_elem = [_normalize_type(t) for t in type_elem]
 
     ttype = ' '.join(type_elem)
     return ttype, name
@@ -529,7 +535,7 @@ def _function_fixup(cursor, domain):
     if template_line:
         full_type.append(template_line)
 
-    full_type.append(cursor.result_type.spelling)
+    full_type.append(_normalize_type(cursor.result_type.spelling))
 
     ttype = ' '.join(full_type)
 

--- a/test/c/autostruct.rst
+++ b/test/c/autostruct.rst
@@ -29,7 +29,7 @@
    Named struct.
 
 
-   .. c:struct:: @anonymous_a63d10331be1a527625db63b8ace540f
+   .. c:struct:: @anonymous_0a4d6f0b47cde0e9872b6dbde2ad1c1a
 
       Anonymous sub-struct.
 
@@ -39,7 +39,7 @@
          Member foo.
 
 
-   .. c:union:: @anonymous_69382278a84175c1cbff40d522114b38
+   .. c:union:: @anonymous_22cf17aa0fa6d83246282a58013db249
 
       Anonymous sub-union.
 

--- a/test/c/function.c
+++ b/test/c/function.c
@@ -1,7 +1,14 @@
+#include <stdbool.h>
+
 /**
  * Foo function.
  */
 static inline int foo(int bar, int baz);
+
+/**
+ * Bool function.
+ */
+bool boolean(bool bar, _Bool baz);
 
 /**
  * No parameters.

--- a/test/c/function.rst
+++ b/test/c/function.rst
@@ -4,6 +4,11 @@
    Foo function.
 
 
+.. c:function:: bool boolean(bool bar, bool baz)
+
+   Bool function.
+
+
 .. c:function:: int no_parameters(void)
 
    No parameters.

--- a/test/c/struct.c
+++ b/test/c/struct.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 /**
  * This is a sample struct
  *
@@ -8,6 +10,14 @@ struct sample_struct {
 	 * member
 	 */
 	int jesh;
+	/**
+	 * bool member
+	 */
+	bool bool_member;
+	/**
+	 * _Bool member
+	 */
+	_Bool _Bool_member;
 	/**
 	 * array member
 	 */

--- a/test/c/struct.rst
+++ b/test/c/struct.rst
@@ -11,6 +11,16 @@
       member
 
 
+   .. c:member:: bool bool_member
+
+      bool member
+
+
+   .. c:member:: bool _Bool_member
+
+      _Bool member
+
+
    .. c:member:: int array_member[5]
 
       array member
@@ -39,7 +49,7 @@
       foo next
 
 
-.. c:struct:: @anonymous_7bf120438d254a91e1275b973de6a0eb
+.. c:struct:: @anonymous_a6168a23d6840e8919ade5661a307607
 
    Anonymous struct documentation.
 
@@ -54,7 +64,7 @@
    Named struct.
 
 
-   .. c:struct:: @anonymous_a63d10331be1a527625db63b8ace540f
+   .. c:struct:: @anonymous_0a4d6f0b47cde0e9872b6dbde2ad1c1a
 
       Anonymous sub-struct.
 
@@ -64,7 +74,7 @@
          Member foo.
 
 
-   .. c:union:: @anonymous_69382278a84175c1cbff40d522114b38
+   .. c:union:: @anonymous_22cf17aa0fa6d83246282a58013db249
 
       Anonymous sub-union.
 

--- a/test/c/variable.c
+++ b/test/c/variable.c
@@ -1,7 +1,19 @@
+#include <stdbool.h>
+
 /**
  * This is a variable document.
  */
 static int sheesh;
+
+/**
+ * Retain bool instead of using _Bool.
+ */
+static bool convert_bool;
+
+/**
+ * Also convert _Bool to bool.
+ */
+static _Bool convert_Bool;
 
 /**
  * function pointer variable

--- a/test/c/variable.rst
+++ b/test/c/variable.rst
@@ -4,6 +4,16 @@
    This is a variable document.
 
 
+.. c:var:: static bool convert_bool
+
+   Retain bool instead of using _Bool.
+
+
+.. c:var:: static bool convert_Bool
+
+   Also convert _Bool to bool.
+
+
 .. c:var:: int (*function_pointer_variable)(int *param_name_ignored)
 
    function pointer variable

--- a/test/cpp/function.rst
+++ b/test/cpp/function.rst
@@ -4,6 +4,11 @@
    Foo function.
 
 
+.. cpp:function:: bool boolean(bool bar, bool baz)
+
+   Bool function.
+
+
 .. cpp:function:: int no_parameters(void)
 
    No parameters.

--- a/test/cpp/struct.rst
+++ b/test/cpp/struct.rst
@@ -11,6 +11,16 @@
       member
 
 
+   .. cpp:member:: public bool bool_member
+
+      bool member
+
+
+   .. cpp:member:: public bool _Bool_member
+
+      _Bool member
+
+
    .. cpp:member:: public int array_member[5]
 
       array member
@@ -39,7 +49,7 @@
       foo next
 
 
-.. cpp:struct:: @anonymous_7bf120438d254a91e1275b973de6a0eb
+.. cpp:struct:: @anonymous_a6168a23d6840e8919ade5661a307607
 
    Anonymous struct documentation.
 
@@ -54,7 +64,7 @@
    Named struct.
 
 
-   .. cpp:struct:: @anonymous_a63d10331be1a527625db63b8ace540f
+   .. cpp:struct:: @anonymous_0a4d6f0b47cde0e9872b6dbde2ad1c1a
 
       Anonymous sub-struct.
 
@@ -64,7 +74,7 @@
          Member foo.
 
 
-   .. cpp:union:: @anonymous_69382278a84175c1cbff40d522114b38
+   .. cpp:union:: @anonymous_22cf17aa0fa6d83246282a58013db249
 
       Anonymous sub-union.
 

--- a/test/cpp/variable.rst
+++ b/test/cpp/variable.rst
@@ -4,6 +4,16 @@
    This is a variable document.
 
 
+.. cpp:var:: static bool convert_bool
+
+   Retain bool instead of using _Bool.
+
+
+.. cpp:var:: static bool convert_Bool
+
+   Also convert _Bool to bool.
+
+
 .. cpp:var:: int (*function_pointer_variable)(int *param_name_ignored)
 
    function pointer variable


### PR DESCRIPTION
After finding the reason for my tokenization difficulties (#184) I decided to have another look at the `_Bool` to `bool` conversion.

Long story short, I've had a change of heart.

Let's keep it simple, and just unconditionally convert `_Bool` to `bool`. That's what folks want, that's the C++ and C23 standard, no need to overcomplicate it, or hold it hostage to some new Hawkmoth Sphinx event extension with cursors passed and bells and whistles. Just do it and move on.
