### PR TITLE
Array symbolic dimensions

### DIFF
--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -426,9 +426,26 @@ def _get_scopedenum_type(cursor):
 def _normalize_type(type_string):
     return 'bool' if type_string == '_Bool' else type_string
 
+def _symbolic_dims(cursor):
+    dim = None
+    for spelling in [t.spelling for t in _cursor_get_tokens(cursor)]:
+        if spelling == '[':
+            # dim should be None here
+            dim = []
+        elif spelling == ']':
+            # dim should not be None here
+            yield ' '.join(dim)
+            dim = None
+        elif dim is not None:
+            dim.append(spelling)
+
 def _dims_fixup(cursor, dims):
     if not dims:
         return ''
+
+    symbolic_dims = list(_symbolic_dims(cursor))
+    if len(symbolic_dims) == len(dims):
+        dims = symbolic_dims
 
     return ''.join([f'[{d}]' for d in dims])
 

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -426,6 +426,12 @@ def _get_scopedenum_type(cursor):
 def _normalize_type(type_string):
     return 'bool' if type_string == '_Bool' else type_string
 
+def _dims_fixup(cursor, dims):
+    if not dims:
+        return ''
+
+    return ''.join([f'[{d}]' for d in dims])
+
 def _var_type_fixup(cursor, domain):
     """Fix non trivial variable and argument types.
 
@@ -437,7 +443,7 @@ def _var_type_fixup(cursor, domain):
     cursor_type = cursor.type
 
     stars_and_quals = ''
-    dims = ''
+    dims = []
     while True:
         if cursor_type.kind == TypeKind.POINTER:
             quals = []
@@ -453,13 +459,15 @@ def _var_type_fixup(cursor, domain):
 
             cursor_type = cursor_type.get_pointee()
         elif cursor_type.kind == TypeKind.CONSTANTARRAY:
-            dims += f'[{cursor_type.element_count}]'
+            dims.append(cursor_type.element_count)
             cursor_type = cursor_type.get_array_element_type()
         elif cursor_type.kind == TypeKind.INCOMPLETEARRAY:
-            dims += '[]'
+            dims.append('')
             cursor_type = cursor_type.get_array_element_type()
         else:
             break
+
+    dims = _dims_fixup(cursor, dims)
 
     type_elem = []
 

--- a/test/c/array-symbolic-dimensions.c
+++ b/test/c/array-symbolic-dimensions.c
@@ -1,0 +1,29 @@
+#define MACRO_SIZE 12
+
+enum {
+	ENUM_SIZE = 4,
+	ENUM_MAX,
+};
+
+/**
+ * array
+ */
+static int foo[MACRO_SIZE];
+
+/**
+ * array
+ */
+static int bar[MACRO_SIZE*ENUM_SIZE][3];
+
+/**
+ * function
+ */
+int array(int foo[MACRO_SIZE/ENUM_SIZE]);
+
+/**
+ * structure
+ */
+struct s {
+	/** member */
+	long m[ENUM_MAX];
+};

--- a/test/c/array-symbolic-dimensions.rst
+++ b/test/c/array-symbolic-dimensions.rst
@@ -1,0 +1,25 @@
+
+.. c:var:: static int foo[MACRO_SIZE]
+
+   array
+
+
+.. c:var:: static int bar[MACRO_SIZE * ENUM_SIZE][3]
+
+   array
+
+
+.. c:function:: int array(int foo[MACRO_SIZE / ENUM_SIZE])
+
+   function
+
+
+.. c:struct:: s
+
+   structure
+
+
+   .. c:member:: long m[ENUM_MAX]
+
+      member
+

--- a/test/c/array-symbolic-dimensions.yaml
+++ b/test/c/array-symbolic-dimensions.yaml
@@ -1,0 +1,6 @@
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
+  - array-symbolic-dimensions.c
+expected: array-symbolic-dimensions.rst

--- a/test/cpp/array-symbolic-dimensions.rst
+++ b/test/cpp/array-symbolic-dimensions.rst
@@ -1,0 +1,25 @@
+
+.. cpp:var:: static int foo[MACRO_SIZE]
+
+   array
+
+
+.. cpp:var:: static int bar[MACRO_SIZE * ENUM_SIZE][3]
+
+   array
+
+
+.. cpp:function:: int array(int foo[MACRO_SIZE / ENUM_SIZE])
+
+   function
+
+
+.. cpp:struct:: s
+
+   structure
+
+
+   .. cpp:member:: public long m[ENUM_MAX]
+
+      member
+

--- a/test/cpp/array-symbolic-dimensions.yaml
+++ b/test/cpp/array-symbolic-dimensions.yaml
@@ -1,0 +1,6 @@
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
+  - ../c/array-symbolic-dimensions.c
+expected: array-symbolic-dimensions.rst


### PR DESCRIPTION
Things like

```
#define SIZE 5
int foo[SIZE];
```

get documented with the actual value 5 rather than the symbolic `SIZE`. Fix it.

(This includes #184 to ensure it works at all.)
