### PR TITLE
Add links to externally hosted source code for documented symbols

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,6 +61,11 @@ if 'READTHEDOCS' in os.environ:
 
 hawkmoth_root = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../test/examples')
 
+source_uri = 'https://github.com/jnikula/hawkmoth/tree/{version}/test/examples/{{source}}#L{{line}}'
+source_version = f'v{version}' if len(version.split('.')) == 3 else 'master'
+
+hawkmoth_source_uri = source_uri.format(version=source_version)
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -85,6 +85,27 @@ See also additional configuration options in the :ref:`built-in extensions
    You can also pass in the compiler to use, for example
    ``get_include_args('gcc')``.
 
+.. py:data:: hawkmoth_source_uri
+   :type: str
+
+   A template URI to source code. If set, add links to externally hosted source
+   code for each documented symbol, similar to the :external+sphinx:doc:`Sphinx
+   linkcode extension <usage/extensions/linkcode>`. Defaults to ``None``.
+
+   The template URI will be formatted using
+   :external+python:py:meth:`str.format`, with the following replacement fields:
+
+   ``{source}``
+     Path to source file relative to :py:data:`hawkmoth_root`.
+   ``{line}``
+     Line number in source file.
+
+   Example:
+
+   .. code-block:: python
+
+      hawkmoth_source_uri = 'https://example.org/src/{source}#L{line}'
+
 .. py:data:: cautodoc_root
    :type: str
 

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -109,11 +109,11 @@ class _AutoBaseDirective(SphinxDirective):
                                     filter_names=self._get_names()):
             num_matches += 1
             for docstr in docstrings.walk(filter_names=self._get_members()):
-                lineoffset = docstr.get_line() - 1
-                lines = docstr.get_docstring(process_docstring=process_docstring)
+                lines, line_number = docstr.get_docstring(process_docstring=process_docstring)
                 for line in lines:
-                    viewlist.append(line, root.get_filename(), lineoffset)
-                    lineoffset += 1
+                    # viewlist line numbers are 0-based
+                    viewlist.append(line, root.get_filename(), line_number - 1)
+                    line_number += 1
 
         return num_matches
 

--- a/src/hawkmoth/__main__.py
+++ b/src/hawkmoth/__main__.py
@@ -55,7 +55,8 @@ def main():
     for comment in comments.walk():
         if args.verbose:
             print(f'# {comment.get_meta()}')
-        print('\n'.join(comment.get_docstring(process_docstring=process_docstring)))
+        lines, _ = comment.get_docstring(process_docstring=process_docstring)
+        print('\n'.join(lines))
 
     for error in errors:
         print(f'{error.level.name}: {error.get_message()}', file=sys.stderr)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -111,7 +111,7 @@ class ParserTestcase(testenv.Testcase):
                 for docstrings in root.walk(recurse=False, filter_types=_filter_types(directive),
                                             filter_names=_filter_names(directive)):
                     for docstr in docstrings.walk(filter_names=_filter_members(directive)):
-                        lines = docstr.get_docstring(process_docstring=process_docstring)
+                        lines, _ = docstr.get_docstring(process_docstring=process_docstring)
                         docs_str += '\n'.join(lines) + '\n'
 
         return docs_str, errors_str


### PR DESCRIPTION
Add `[source]` links for documented symbols, similar to what sphinx.ext.viewcode and sphinx.ext.linkcode do.

https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html
https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html

Running `make html` and looking at examples.html gives the best idea what this does.
