### PR TITLE
parser: fix parsing of anonymous entities with clang 16+

### DIFF
--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -507,8 +507,14 @@ def _type_definition_fixup(cursor):
     type_elem = []
 
     # Short cut for anonymous symbols.
-    if cursor.spelling == '':
+    if cursor.is_anonymous():
         return None
+
+    # libclang 16 and later have cursor.spelling == cursor.type.spelling for
+    # typedefs of anonymous entities, while libclang 15 and earlier have an
+    # empty string. Match the behaviour across libclang versions.
+    if cursor.spelling == '':
+        return cursor.type.spelling
 
     type_elem.extend(_specifiers_fixup(cursor, cursor.type))
 

--- a/test/c/typedef-enum.rst
+++ b/test/c/typedef-enum.rst
@@ -9,7 +9,7 @@
       named enumeration
 
 
-.. c:enum:: @anonymous_90372874a3c8c25dccf983612f39e93f
+.. c:enum:: unnamed_t
 
    unnamed typedeffed enum
 

--- a/test/c/typedef-struct.rst
+++ b/test/c/typedef-struct.rst
@@ -9,7 +9,7 @@
       named member
 
 
-.. c:struct:: @anonymous_7f9a1d628cd33f3227f3fcdc3a405aa6
+.. c:struct:: typedef_struct
 
    unnamed typedeffed struct
 

--- a/test/cpp/typedef-enum.rst
+++ b/test/cpp/typedef-enum.rst
@@ -9,7 +9,7 @@
       named enumeration
 
 
-.. cpp:enum:: @anonymous_90372874a3c8c25dccf983612f39e93f
+.. cpp:enum:: unnamed_t
 
    unnamed typedeffed enum
 

--- a/test/cpp/typedef-struct.rst
+++ b/test/cpp/typedef-struct.rst
@@ -9,7 +9,7 @@
       named member
 
 
-.. cpp:struct:: @anonymous_7f9a1d628cd33f3227f3fcdc3a405aa6
+.. cpp:struct:: typedef_struct
 
    unnamed typedeffed struct
 


### PR DESCRIPTION
Clang 16 started returning names for anonymous entities [1], of the form:

(unnamed <entity> at /path/to/file:<line>:<column>)

Additionally check for is_anonymous().

[1] https://github.com/llvm/llvm-project/commit/19e984ef8f49bc3ccced15621989fa9703b2cd5b

---

I'm not sure if this actually fixes anything, because I didn't try to install clang 16 yet. But at least this doesn't break anything on my clang 14.

Maybe a fix to #189.