### PR TITLE
Fix and capture test app build warnings

### DIFF
--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -8,6 +8,7 @@ import tempfile
 
 import pytest
 from sphinx.application import Sphinx
+from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 from test import testenv
 
@@ -22,21 +23,23 @@ class ExtensionTestcase(testenv.Testcase):
     def _sphinx_build(self, srcdir):
         outdir = os.path.join(srcdir, self._buildername)
         doctreedir = os.path.join(srcdir, 'doctrees')
+        confdir = testenv.testdir
 
-        app = Sphinx(srcdir=srcdir, confdir=testenv.testdir, outdir=outdir,
-                     doctreedir=doctreedir, buildername=self._buildername)
+        with patch_docutils(confdir), docutils_namespace():
+            app = Sphinx(srcdir=srcdir, confdir=confdir, outdir=outdir,
+                         doctreedir=doctreedir, buildername=self._buildername)
 
-        # Set root to the directory the testcase yaml is in, because the
-        # filenames in yaml are relative to it.
-        app.config.hawkmoth_root = os.path.dirname(self.filename)
+            # Set root to the directory the testcase yaml is in, because the
+            # filenames in yaml are relative to it.
+            app.config.hawkmoth_root = os.path.dirname(self.filename)
 
-        # Hack: It's not possible to disable search via configuration
-        app.builder.search = False
+            # Hack: It's not possible to disable search via configuration
+            app.builder.search = False
 
-        app.build()
+            app.build()
 
-        output_suffix = self._get_suffix()
-        output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
+            output_suffix = self._get_suffix()
+            output_filename = os.path.join(app.outdir, f'index.{output_suffix}')
 
         return testenv.read_file(output_filename), None
 

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2018-2023, Jani Nikula <jani@nikula.org>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 
+import io
 import os
 import shutil
 import tempfile
@@ -29,9 +30,15 @@ class ExtensionTestcase(testenv.Testcase):
         # Don't emit color codes in Sphinx status/warning output
         console.nocolor()
 
+        warning = io.StringIO()
+
         with patch_docutils(confdir), docutils_namespace():
             app = Sphinx(srcdir=srcdir, confdir=confdir, outdir=outdir,
-                         doctreedir=doctreedir, buildername=self._buildername)
+                         doctreedir=doctreedir, buildername=self._buildername,
+                         warning=warning)
+
+            # Ensure there are no errors with app creation.
+            assert warning.getvalue() == ''
 
             # Set root to the directory the testcase yaml is in, because the
             # filenames in yaml are relative to it.

--- a/test/test_cautodoc.py
+++ b/test/test_cautodoc.py
@@ -9,6 +9,7 @@ import tempfile
 import pytest
 from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace, patch_docutils
+from sphinx.util import console
 
 from test import testenv
 
@@ -24,6 +25,9 @@ class ExtensionTestcase(testenv.Testcase):
         outdir = os.path.join(srcdir, self._buildername)
         doctreedir = os.path.join(srcdir, 'doctrees')
         confdir = testenv.testdir
+
+        # Don't emit color codes in Sphinx status/warning output
+        console.nocolor()
 
         with patch_docutils(confdir), docutils_namespace():
             app = Sphinx(srcdir=srcdir, confdir=confdir, outdir=outdir,


### PR DESCRIPTION
Fix docutils warnings in `app = Sphinx()`. They're usually not visible, but when hitting other errors, pytest has captured the stderr and emits the warnings. Fix them, capture the stderr, ensure there are no errors with `app = Sphinx()` going forward, and compare the errors against expected errors like the parser tests do.
