### PR TITLE
test: query system include args from clang

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+      - name: Install dependencies (apt)
+        run: sudo apt-get install -y python3-clang python3-pip
       - name: Examples check
         run: |
           . venv

--- a/test/conf.py
+++ b/test/conf.py
@@ -3,6 +3,8 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+from hawkmoth.util import compiler
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
@@ -29,6 +31,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
+# -- Options for Hawkmoth ----------------------------------------------------
+# https://jnikula.github.io/hawkmoth/dev/extension.html#configuration
+
+hawkmoth_clang = compiler.get_include_args()
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -7,9 +7,13 @@ import sys
 import pytest
 import strictyaml
 
+from hawkmoth.util import compiler
+
 testext = '.yaml'
 testdir = os.path.dirname(os.path.abspath(__file__))
 rootdir = os.path.dirname(testdir)
+
+_clang_include_args = compiler.get_include_args()
 
 sys.path.insert(0, rootdir)
 
@@ -47,6 +51,8 @@ class Directive:
         # can use C sources for C++ tests. The yaml may override this in cases
         # where we want to force a mismatch.
         clang_args = ['-xc++'] if self.domain == 'cpp' else ['-xc']
+
+        clang_args.extend(_clang_include_args.copy())
 
         clang_args.extend(self.options.get('clang', []))
 


### PR DESCRIPTION
Apparently libclang (and consequently Clang Python Bindings) does not universally get its system include paths right by default, or the same as clang. The defaults work on Debian, but not on Fedora, for example, and I've been unable to root cause this.

Anyway, we already have a helper for querying the system include args from clang, so use it.

Fixes #193.