### PR TITLE
test: use pyproject.toml for pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,12 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--strict-markers"
+markers = [
+    "full",
+]
+testpaths = [
+    "test",
+]

--- a/test/Makefile.local
+++ b/test/Makefile.local
@@ -8,23 +8,23 @@ RST := $(RST) $(test_dir)/README.rst
 
 .PHONY: test
 test:
-	pytest -n auto $(test_dir)
+	pytest -n auto
 
 test-verbose:
-	pytest -n auto -vv $(test_dir)
+	pytest -n auto -vv
 
 # Ensure a) update-examples works, and b) examples have been updated.
 test-examples:
 	$(test_dir)/update-examples.py | diff -u $(docdir)/examples.rst -
 
 quick-test:
-	pytest -n auto -m "not full" $(test_dir)
+	pytest -n auto -m "not full"
 
 test-coverage:
-	pytest -n auto --cov=src/hawkmoth --cov-report=term $(test_dir)
+	pytest -n auto --cov=src/hawkmoth --cov-report=term
 
 test-coverage-html:
-	pytest -n auto --cov=src/hawkmoth --cov-report=term --cov-report=html:$(test_dir)/coverage-report $(test_dir)
+	pytest -n auto --cov=src/hawkmoth --cov-report=term --cov-report=html:$(test_dir)/coverage-report
 	@echo "Coverage report: file://$(CURDIR)/$(test_dir)/coverage-report/index.html"
 
 CLEAN := $(CLEAN) .coverage $(test_dir)/coverage-report

--- a/test/README.rst
+++ b/test/README.rst
@@ -22,7 +22,8 @@ There are three test files, with different levels and approaches, run by
   Test the parser and the command-line interface. The documentation comments are
   extracted through the command-line interface.
 
-* ``test_text()`` and ``test_html()`` in ``test_cautodoc.py``
+* ``test_directive_text()`` and ``test_directive_html()`` in
+  ``test_cautodoc.py``
 
   Test the parser and the Sphinx extension, using two builders: text and
   html. The documentation comments are extracted through the Sphinx build
@@ -40,22 +41,23 @@ Test Cases
 
 The test functions described above are parametrized using what we call test
 cases. Each test case is defined by a ``.yaml`` file. The ``.yaml`` defines the
-configuration, the input C source file, the expected reStructuredText output
-file, and optionally a diagnostics (error messages) output file.
+configuration, the input C or C++ source file, the expected reStructuredText
+output file, and optionally a diagnostics (error messages) output file.
 
 The YAML is parsed using StrictYAML, using a schema defined in ``testenv.py``.
 
-The basename of the ``.yaml`` file becomes the parametrized test case name in
-``pytest``.
+The test approach, the relative path and the basename of the ``.yaml`` file
+define the parametrized test case name in ``pytest``, for example
+``test_parser[c/struct]``.
 
 Test Cases as Examples
 ----------------------
 
-The examples in the documentation are generated from test cases named
-``example-*``, ensuring the examples actually work.
+The examples in the documentation are generated from test cases under the
+``examples`` subdirectory, ensuring the examples actually work.
 
 ``make update-examples`` runs ``update-examples.py`` to generate
-``doc/examples.rst``.
+``doc/examples.rst`` from the example test cases.
 
 Running
 -------
@@ -67,10 +69,10 @@ Running individual test approaches, for examples ``test_parser``::
 
   $ pytest -k test_parser
 
-Run individual test cases, for example ``struct``::
+Run individual test cases, for example ``c/struct``::
 
-  $ pytest -k [struct]
+  $ pytest -k c/struct
 
 Combined, with verbose output, for example::
 
-  $ pytest -v -k test_cli[struct]
+  $ pytest -v -k test_cli[c/struct]

--- a/test/README.rst
+++ b/test/README.rst
@@ -65,12 +65,12 @@ plugin parallelizes test execution.
 
 Running individual test approaches, for examples ``test_parser``::
 
-  $ pytest -k test_parser test
+  $ pytest -k test_parser
 
 Run individual test cases, for example ``struct``::
 
-  $ pytest -k [struct] test
+  $ pytest -k [struct]
 
 Combined, with verbose output, for example::
 
-  $ pytest -v -k test_cli[struct] test
+  $ pytest -v -k test_cli[struct]

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    full: the full test set (quick test with '-m "not full"')


### PR DESCRIPTION
Running pytest at the top level directory without specifying the test subdir on the command-line fails to find test/pytest.ini, leading to warnings about markers: PytestUnknownMarkWarning: Unknown pytest.mark.full.

Rather than moving pytest.ini to top level, use pyproject.toml for pytest configuration, and specify the test paths there. Remove the test subdir from the make targets and the README. Additionally specify strict markers while at it.

With this, folks can run tests simply with 'pytest' on the command-line, without warnings.