### PR TITLE
allow documentation build using hawkmoth from source tree

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Build docs
         run: |
           . venv
-          sphinx-build doc _build
+          make html
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.name }}
-          path: _build
+          path: doc/_build/html
           if-no-files-found: error
 
   deploy-docs:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -66,4 +66,4 @@ jobs:
       - name: Documentation build check
         run: |
           . venv
-          make SPHINXOPTS=-Wn html
+          make O=-Wn html

--- a/doc/Makefile.local
+++ b/doc/Makefile.local
@@ -10,7 +10,7 @@ docdir := $(dir)
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -t use-installed-hawkmoth
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = $(docdir)
 BUILDDIR      = $(docdir)/_build

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,6 +6,11 @@
 import os
 import sys
 
+# Use the installed Hawkmoth package for CI, testing, and Read the Docs, while
+# allowing documentation build using Hawkmoth from the source tree.
+if not tags.has('use-installed-hawkmoth') and 'READTHEDOCS' not in os.environ:
+    sys.path.insert(0, os.path.abspath('../src'))
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 


### PR DESCRIPTION
Address #203 while also using the installed package for CI and testing. Best of both worlds?

