### PR TITLE
extension: map parser CRITICAL loglevel to Sphinx ERROR

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -44,7 +44,7 @@ class _AutoBaseDirective(SphinxDirective):
             ErrorLevel.INFO: 'VERBOSE',
             ErrorLevel.WARNING: 'WARNING',
             ErrorLevel.ERROR: 'ERROR',
-            ErrorLevel.CRITICAL: 'CRITICAL',
+            ErrorLevel.CRITICAL: 'ERROR',
         }
 
         for error in errors:


### PR DESCRIPTION
Sphinx does recognize CRITICAL loglevel, but internally it never uses it, and it does not color highlight CRITICAL the way it highlights ERROR.

Map parser CRITICAL to Sphinx ERROR level to get the console highlighting.

See also https://github.com/sphinx-doc/sphinx/blob/master/sphinx/util/logging.py#L45
