### PR TITLE
Add basic support for C++ namespaces

### DIFF
--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -531,7 +531,12 @@ class DocCursor:
             if child._cc.kind == CursorKind.CXX_BASE_SPECIFIER:
                 def pad(s): return s + ' ' if s else ''
                 access_spec = child._get_access_specifier()
-                inherited.append(f'{pad(access_spec)}{child._cc.type.spelling}')
+                if child._cc.referenced.kind == CursorKind.CLASS_DECL:
+                    # use referenced type if possible for full namespace
+                    spelling = child._cc.referenced.type.spelling
+                else:
+                    spelling = child._cc.type.spelling
+                inherited.append(f'{pad(access_spec)}{spelling}')
 
         return ': ' + ', '.join(inherited) if len(inherited) > 0 else None
 

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -321,6 +321,17 @@ def _parse_undocumented_block(errors, cursor, nest):
                 if c.comment:
                     ret.extend(_recursive_parse(errors, c, nest))
 
+    elif cursor.kind == CursorKind.NAMESPACE:
+        # ignore internal STL namespaces
+        if cursor.name in ['std', '__gnu_cxx', '__cxxabiv1', '__gnu_debug']:
+            return ret
+        # iterate over namespace
+        for c in cursor.get_children():
+            if c.comment:
+                ret.extend(_recursive_parse(errors, c, nest))
+            else:
+                ret.extend(_parse_undocumented_block(errors, c, nest))
+
     return ret
 
 def _language_option(filename, domain):


### PR DESCRIPTION
Closes #209

I added support for C++ namespace based on #206. It was actually not too hard, it's basically just adding a cursor kind check in `_parse_undocumented_block`. 

The nasty part was working around the `Docstring` class, as it expects a commented cursor. I wondering if it is worth to add a `BasicDocstring` class, which does not require this.

The implementation I chose uses the namespacing directives from sphinx (https://www.sphinx-doc.org/en/master/usage/domains/cpp.html#namespacing), as it is significantly easier than adding the namespace attribute in front of every symbol correctly. This does mean that the namespace is not shown in the documentation at all.

Basically there two things missing:
- [ ] Add an option to add a paragraphs for namespaces (including filters)
- [ ] Ensure that namespace objects are kept when filtering for specific symbol and not the entire file

It should be mentioned that `using namespace XYZ;` is entirely ignored, but I don't think there is a sane way to fix that, and it shouldn't be used in headers anyway.