### PR TITLE
Use -xc++-header instead of -xc++ in cpp domain

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -53,9 +53,9 @@ class _AutoBaseDirective(SphinxDirective):
                             location=(self.env.docname, self.lineno))
 
     def __get_clang_args(self):
-        # Always pass `-xc++` to the compiler on 'cpp' domain as the first
+        # Always pass `-xc++-header` to the compiler on 'cpp' domain as the first
         # option so that the user can override it.
-        clang_args = ['-xc++'] if self._domain == 'cpp' else []
+        clang_args = ['-xc++-header'] if self._domain == 'cpp' else []
 
         clang_args.extend(self.env.config.hawkmoth_clang.copy())
 


### PR DESCRIPTION
Closes #208

By default, hawkmoth added the -xc++ compiler argument to clang, which caused issues with pragma only declaration (See https://github.com/jnikula/hawkmoth/issues/208). Changig this to -xc++-header solves this issue, while retaining compatibility with compiled units.