### PR TITLE
Unify -x<language> option usage

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -69,8 +69,8 @@ class _AutoBaseDirective(SphinxDirective):
         # Cached parse results per rst document
         parsed_files = self.env.temp_data.setdefault('hawkmoth_parsed_files', {})
 
-        # The output depends on clang args
-        key = (filename, tuple(clang_args))
+        # The output depends on domain and clang args
+        key = (filename, self._domain, tuple(clang_args))
 
         if key in parsed_files:
             return
@@ -85,11 +85,15 @@ class _AutoBaseDirective(SphinxDirective):
 
         parsed_files[key] = docstrings
 
-    def __parsed_files(self, filter_filenames=None, filter_clang_args=None):
+    def __parsed_files(self, filter_filenames=None, filter_domains=None,
+                       filter_clang_args=None):
         parsed_files = self.env.temp_data.get('hawkmoth_parsed_files', {})
 
         for root in parsed_files.values():
             if filter_filenames is not None and root.get_filename() not in filter_filenames:
+                continue
+
+            if filter_domains is not None and root.get_domain() not in filter_domains:
                 continue
 
             if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
@@ -121,6 +125,7 @@ class _AutoBaseDirective(SphinxDirective):
     def __get_docstrings(self, viewlist):
         num_matches = 0
         for root in self.__parsed_files(filter_filenames=self._get_filenames(),
+                                        filter_domains=[self._domain],
                                         filter_clang_args=[self.__get_clang_args()]):
             num_matches += self.__get_docstrings_for_root(viewlist, root)
 

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -53,9 +53,7 @@ class _AutoBaseDirective(SphinxDirective):
                             location=(self.env.docname, self.lineno))
 
     def __get_clang_args(self):
-        # Always pass `-xc++` to the compiler on 'cpp' domain as the first
-        # option so that the user can override it.
-        clang_args = ['-xc++'] if self._domain == 'cpp' else []
+        clang_args = []
 
         clang_args.extend(self.env.config.hawkmoth_clang.copy())
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -77,7 +77,7 @@ class ParserTestcase(testenv.Testcase):
 
             clang_args = directive.get_clang_args()
 
-            key = (filename, tuple(clang_args))
+            key = (filename, directive.domain, tuple(clang_args))
             if key in roots:
                 continue
 
@@ -91,10 +91,14 @@ class ParserTestcase(testenv.Testcase):
         for directive in self.directives:
             filename = directive.get_input_filename()
             filter_filenames = [filename] if filename is not None else None
+            filter_domains = [directive.domain]
             filter_clang_args = [directive.get_clang_args()]
 
             for root in roots.values():
                 if filter_filenames is not None and root.get_filename() not in filter_filenames:
+                    continue
+
+                if filter_domains is not None and root.get_domain() not in filter_domains:
                     continue
 
                 if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -47,10 +47,7 @@ class Directive:
         return directive_str
 
     def get_clang_args(self):
-        # Default to compile as C++ if the test is for the C++ domain so that we
-        # can use C sources for C++ tests. The yaml may override this in cases
-        # where we want to force a mismatch.
-        clang_args = ['-xc++'] if self.domain == 'cpp' else ['-xc']
+        clang_args = []
 
         clang_args.extend(_clang_include_args.copy())
 


### PR DESCRIPTION
Move the clang language selection at a lower level, do it unconditionally, and add -header too. This unifies -x option across the extension, tests ,and cli.

Fixes #208 
