### PR TITLE
setup: move flake8 configuration to setup.cfg

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -17,15 +17,10 @@ dir := .
 
 RST := $(RST) CHANGELOG.rst CONTRIBUTING.rst README.rst
 
-FLAKE8_IGNORE=\
-	E302,\
-	E305,\
-	E731
-
 # Static analysis
 .PHONY: check
 check:
-	flake8 --extend-ignore="$(FLAKE8_IGNORE)" --max-line-length=100 src/hawkmoth test
+	flake8 src/hawkmoth test
 
 .PHONY: check-rst
 check-rst:

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,3 +58,7 @@ hawkmoth =
 [options.entry_points]
 console_scripts =
     hawkmoth = hawkmoth.__main__:main
+
+[flake8]
+extend-ignore = E302,E305,E731
+max-line-length = 100


### PR DESCRIPTION
Flake8 will find its configuration in a number of places by itself, including in 'setup.cfg'. Moving the configuration there allows flake8 to find it when being executed outside of the makefiles' environment.