### PR TITLE
Fix references to typedefs of anonymous struct/union/enum on clang 15 and earlier

### DIFF
--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -62,7 +62,7 @@ class DocCursor:
 
     @property
     def name(self):
-        return self._cc.spelling
+        return self._cc.spelling if self._cc.spelling else self.decl_name
 
     @property
     def decl_name(self):
@@ -75,7 +75,8 @@ class DocCursor:
                              CursorKind.CLASS_TEMPLATE]:
             return self._type_definition_fixup()
         else:
-            return self.name
+            # self.name would recurse back here if self._cc.spelling is None
+            return self._cc.spelling
 
     @property
     def type(self):

--- a/test/c/typedef-struct.yaml
+++ b/test/c/typedef-struct.yaml
@@ -1,6 +1,16 @@
 directives:
 - domain: c
-  directive: autodoc
+  directive: autostruct
   arguments:
-  - typedef-struct.c
+  - named
+  options:
+    file: typedef-struct.c
+    members:
+- domain: c
+  directive: autostruct
+  arguments:
+  - typedef_struct
+  options:
+    file: typedef-struct.c
+    members:
 expected: typedef-struct.rst


### PR DESCRIPTION
Fix for #201 
