### PR TITLE
doccursor: expose cursor location

### DIFF
--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -49,6 +49,10 @@ class DocCursor:
         }
 
     @property
+    def location(self):
+        return self._cc.location
+
+    @property
     def comment(self):
         return self._comment.spelling if self._comment else None
 


### PR DESCRIPTION
This is used to get the file name and line for error messages in the parser. Naturally we need to expose it.