### PR TITLE
setup: move flake8 filename patterns to setup.cfg

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -20,7 +20,7 @@ RST := $(RST) CHANGELOG.rst CONTRIBUTING.rst README.rst
 # Static analysis
 .PHONY: check
 check:
-	flake8 src/hawkmoth test
+	flake8
 
 .PHONY: check-rst
 check-rst:

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,5 +60,8 @@ console_scripts =
     hawkmoth = hawkmoth.__main__:main
 
 [flake8]
+filename =
+    src/hawkmoth
+    test
 extend-ignore = E302,E305,E731
 max-line-length = 100


### PR DESCRIPTION
Commit dc17f4165508 ("setup: move flake8 configuration to setup.cfg") moved flake8 ignore patterns and line length config to setup.cfg. Also move the filename patterns there.