### PR TITLE
examples: mention that source links are optional

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -8,6 +8,9 @@ Examples
 
 This page showcases Hawkmoth in action.
 
+The ``[source]`` links are optional, and can be enabled via the
+:py:data:`hawkmoth_source_uri` option.
+
 .. contents::
    :local:
    :depth: 1

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -33,6 +33,9 @@ Examples
 
 This page showcases Hawkmoth in action.
 
+The ``[source]`` links are optional, and can be enabled via the
+:py:data:`hawkmoth_source_uri` option.
+
 .. contents::
    :local:
    :depth: 1


### PR DESCRIPTION
Some folks might be put off by the source links, others might struggle figuring out how they're enabled. Pointing at the option helps both.