### PR TITLE
Cursor prop cache v2

### DIFF
--- a/src/hawkmoth/__main__.py
+++ b/src/hawkmoth/__main__.py
@@ -14,6 +14,7 @@ import sys
 from hawkmoth.ext import javadoc
 from hawkmoth.ext import napoleon
 from hawkmoth.parser import parse
+from hawkmoth.doccursor import DocCursor
 
 def filename(file):
     if os.path.isfile(file):
@@ -62,6 +63,9 @@ def main():
                         help='Argument to pass to Clang. May be specified multiple times. See hawkmoth_clang.')  # noqa: E501
     parser.add_argument('--verbose', dest='verbose', action='store_true',
                         help='Verbose output.')
+    parser.add_argument('--cursor-cache-info', dest='cursor_cache_info',
+                        action='store_true',
+                        help='Print cursor cache information.')
     parser.add_argument('--version', action='version',
                         version=f'%(prog)s {_read_version()}',
                         help='Show version and exit')
@@ -82,6 +86,10 @@ def main():
 
     for error in errors:
         print(f'{error.level.name}: {error.get_message()}', file=sys.stderr)
+
+    if args.cursor_cache_info:
+        print('>>> Cursor cache info:')
+        print(DocCursor.cache_info())
 
 if __name__ == '__main__':
     main()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from hawkmoth.doccursor import DocCursor
+
+def pytest_sessionfinish(session, exitstatus):
+    print('\n>>> DocCursor cache stats:', file=sys.stderr)
+    print(DocCursor.cache_info(), file=sys.stderr)


### PR DESCRIPTION
Here is the new cache with the `functools` decorator. As expected, that pitfall was actually the feature I wanted all along. 2 equal `DocCursor` instances are able to reuse the same values, which is a win when iterating over children / parents when traversing the AST, possibly multiple times.

From limited testing and looking at the code, I have the impression this currently benefits C++ code more than C (greater need to look into parents and children of any given cursor, constantly hitting the same types and so on). With instrumentation of the code, I saw some methods save 50+% of all calls when running the test suite, but I need to look at it better. **This is meant only for show and tell at this point.**

Sadly this did not improve performance (still over the test suite) in any measurable way. If anything it makes it ever so slightly worse (some <0.1s per run on average on my machine).

Some of the cached methods were never triggered twice for the same cursor within our code, so I tried enabling cache only for those that showed promising numbers. But no measurable difference there, so this branch is enabling cache for all methods that are called from more than one place in our code and / or are directly exposed through the cursor's API (with one exception as noted in the relevant commit).

Performance wise this doesn't worry me, I think it's worth it for future proofing all sorts of use cases within events and so on. But not sure all methods deserve an equally large maximum cache size or what the defaults should be. Also don't know hoe to best expose tuning and profiling values to the user.