### PR TITLE
Add support for C++ using type definitions

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -281,7 +281,7 @@ class CppAutoVarDirective(_AutoSymbolDirective):
 
 class CppAutoTypeDirective(_AutoSymbolDirective):
     _domain = 'cpp'
-    _docstring_types = [docstring.TypedefDocstring]
+    _docstring_types = [docstring.TypedefDocstring, docstring.TypeAliasDocstring]
 
 class CppAutoMacroDirective(_AutoSymbolDirective):
     _domain = 'cpp'

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -244,7 +244,7 @@ class CAutoVarDirective(_AutoSymbolDirective):
 
 class CAutoTypeDirective(_AutoSymbolDirective):
     _domain = 'c'
-    _docstring_types = [docstring.TypeDocstring]
+    _docstring_types = [docstring.TypedefDocstring]
 
 class CAutoMacroDirective(_AutoSymbolDirective):
     _domain = 'c'
@@ -281,7 +281,7 @@ class CppAutoVarDirective(_AutoSymbolDirective):
 
 class CppAutoTypeDirective(_AutoSymbolDirective):
     _domain = 'cpp'
-    _docstring_types = [docstring.TypeDocstring]
+    _docstring_types = [docstring.TypedefDocstring]
 
 class CppAutoMacroDirective(_AutoSymbolDirective):
     _domain = 'cpp'

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -236,6 +236,22 @@ class TypedefDocstring(Docstring):
     _indent = 1
     _fmt = '.. {domain}:type:: {name}'
 
+class TypeAliasDocstring(Docstring):
+    _indent = 1
+    _fmt = '.. cpp:type:: {name} = {underlying_type}'
+
+    def __init__(self, cursor, nest):
+        self._underlying_type = cursor.value
+        super().__init__(cursor=cursor, nest=nest)
+
+    def _get_header_lines(self):
+        name = self._get_decl_name()
+        underlying_type = self._underlying_type.spelling
+
+        header = self._fmt.format(name=name, underlying_type=underlying_type)
+
+        return header.splitlines()
+
 class _CompoundDocstring(Docstring):
     def _get_decl_name(self):
         # If decl_name is empty, it means this is an anonymous declaration.

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -232,7 +232,7 @@ class VarDocstring(Docstring):
 
         return header.splitlines()
 
-class TypeDocstring(Docstring):
+class TypedefDocstring(Docstring):
     _indent = 1
     _fmt = '.. {domain}:type:: {name}'
 

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -217,7 +217,7 @@ def _recursive_parse(errors, cursor, nest):
 
     elif cursor.kind == CursorKind.TYPEDEF_DECL:
 
-        ds = docstring.TypeDocstring(cursor=cursor, nest=nest)
+        ds = docstring.TypedefDocstring(cursor=cursor, nest=nest)
 
         return [ds]
 

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -221,6 +221,12 @@ def _recursive_parse(errors, cursor, nest):
 
         return [ds]
 
+    elif cursor.kind in [CursorKind.TYPE_ALIAS_DECL, CursorKind.TYPE_ALIAS_TEMPLATE_DECL]:
+
+        ds = docstring.TypeAliasDocstring(cursor=cursor, nest=nest)
+
+        return [ds]
+
     elif cursor.kind in [CursorKind.STRUCT_DECL,
                          CursorKind.UNION_DECL,
                          CursorKind.ENUM_DECL,

--- a/test/cpp/autotype.rst
+++ b/test/cpp/autotype.rst
@@ -1,0 +1,5 @@
+
+.. cpp:type:: template<typename T, typename... Args> foonestalias = foovaralias<footmplalias<T>, Args...>
+
+   Nested template alias
+

--- a/test/cpp/autotype.yaml
+++ b/test/cpp/autotype.yaml
@@ -1,0 +1,8 @@
+directives:
+- domain: cpp
+  directive: autotype
+  arguments:
+  - foonestalias
+  options:
+    file: using-alias.cpp
+expected: autotype.rst

--- a/test/cpp/using-alias.cpp
+++ b/test/cpp/using-alias.cpp
@@ -1,0 +1,17 @@
+/** Type alias */
+using footypealias = int;
+
+/** Function alias */
+using foofctalias = void(int, int);
+
+/** Template alias */
+template<typename T>
+using footmplalias = T*;
+
+/** Variadic template alias */
+template<typename... Args>
+using foovaralias = void(footypealias, Args...);
+
+/** Nested template alias */
+template<typename T, typename... Args>
+using foonestalias = foovaralias<footmplalias<T>, Args...>;

--- a/test/cpp/using-alias.rst
+++ b/test/cpp/using-alias.rst
@@ -1,0 +1,25 @@
+
+.. cpp:type:: footypealias = int
+
+   Type alias
+
+
+.. cpp:type:: foofctalias = void (int, int)
+
+   Function alias
+
+
+.. cpp:type:: template<typename T> footmplalias = T *
+
+   Template alias
+
+
+.. cpp:type:: template<typename... Args> foovaralias = void (footypealias, Args...)
+
+   Variadic template alias
+
+
+.. cpp:type:: template<typename T, typename... Args> foonestalias = foovaralias<footmplalias<T>, Args...>
+
+   Nested template alias
+

--- a/test/cpp/using-alias.yaml
+++ b/test/cpp/using-alias.yaml
@@ -1,0 +1,6 @@
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
+  - using-alias.cpp
+expected: using-alias.rst

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -27,7 +27,7 @@ def _filter_types(directive):
         'autodoc': None,
         'autosection': [docstring.TextDocstring],
         'autovar': [docstring.VarDocstring],
-        'autotype': [docstring.TypeDocstring],
+        'autotype': [docstring.TypedefDocstring],
         'autostruct': [docstring.StructDocstring],
         'autounion': [docstring.UnionDocstring],
         'autoenum': [docstring.EnumDocstring],

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -27,7 +27,7 @@ def _filter_types(directive):
         'autodoc': None,
         'autosection': [docstring.TextDocstring],
         'autovar': [docstring.VarDocstring],
-        'autotype': [docstring.TypedefDocstring],
+        'autotype': [docstring.TypedefDocstring, docstring.TypeAliasDocstring],
         'autostruct': [docstring.StructDocstring],
         'autounion': [docstring.UnionDocstring],
         'autoenum': [docstring.EnumDocstring],


### PR DESCRIPTION
This PR adds support for `using typeA = typeB` via the [`cpp:type`](https://www.sphinx-doc.org/en/master/usage/domains/cpp.html#directive-cpp-type) type alias declaration.

Up for discussion: I stored the "underlying type" in the `value` property of the cursor, since that is what felt most natural to me given the C++ syntax.

I added a test case, however two of the three tests fail (`test/test_cautodoc.py::test_directive_text[cpp/using-alias]` and `test/test_cautodoc.py::test_directive_html[cpp/using-alias]`). Since I don't really understand why they fail, I need to help here.