### PR TITLE
Revert "setup: move flake8 filename patterns to setup.cfg"

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -20,7 +20,7 @@ RST := $(RST) CHANGELOG.rst CONTRIBUTING.rst README.rst
 # Static analysis
 .PHONY: check
 check:
-	flake8
+	flake8 src/hawkmoth test
 
 .PHONY: check-rst
 check-rst:

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,8 +60,5 @@ console_scripts =
     hawkmoth = hawkmoth.__main__:main
 
 [flake8]
-filename =
-    src/hawkmoth
-    test
 extend-ignore = E302,E305,E731
 max-line-length = 100


### PR DESCRIPTION
This reverts commit 9c20afb4702c31050b956af7612614a3adffde9b.

Turns out the filename config doesn't do what I thought it does. It lists filename patterns within paths, not files or directories to check, and the change skipped everything.