### PR TITLE
style: follow pep8 on lambda assignments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,5 +60,5 @@ console_scripts =
     hawkmoth = hawkmoth.__main__:main
 
 [flake8]
-extend-ignore = E302,E305,E731
+extend-ignore = E302,E305
 max-line-length = 100

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -105,7 +105,7 @@ class _AutoBaseDirective(SphinxDirective):
         self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
 
     def __get_docstrings_for_root(self, viewlist, root):
-        process_docstring = lambda lines: self.__process_docstring(lines)
+        def process_docstring(lines): self.__process_docstring(lines)
 
         num_matches = 0
         for docstrings in root.walk(recurse=False, filter_types=self._docstring_types,

--- a/src/hawkmoth/__main__.py
+++ b/src/hawkmoth/__main__.py
@@ -84,9 +84,9 @@ def main():
     comments, errors = parse(args.file, domain=args.domain, clang_args=args.clang)
 
     if args.process_docstring:
-        process_docstring = lambda lines: _process_docstring(args.process_docstring, lines)
+        def process_docstring(lines): return _process_docstring(args.process_docstring, lines)
     else:
-        process_docstring = lambda lines: _process_docstring_compat(args, lines)
+        def process_docstring(lines): return _process_docstring_compat(args, lines)
 
     for comment in comments.walk():
         if args.verbose:

--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -501,7 +501,7 @@ class DocCursor:
         inherited = []
         for child in self.get_children():
             if child._cc.kind == CursorKind.CXX_BASE_SPECIFIER:
-                pad = lambda s: s + ' ' if s else ''
+                def pad(s): return s + ' ' if s else ''
                 access_spec = child._get_access_specifier()
                 inherited.append(f'{pad(access_spec)}{child._cc.type.spelling}')
 
@@ -568,7 +568,7 @@ class DocCursor:
             type_elem.append(access_spec)
 
         if cursor_type.kind == TypeKind.FUNCTIONPROTO:
-            pad = lambda s: s if s.endswith('*') or s.endswith('&') else s + ' '
+            def pad(s): return s if s.endswith('*') or s.endswith('&') else s + ' '
 
             args = []
             for c in cursor.get_children():

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -369,8 +369,8 @@ class FunctionDocstring(Docstring):
 
         args = ''
         if self._args and len(self._args) > 0:
-            pad_type = lambda t: '' if len(t) == 0 or t.endswith('*') or t.endswith('&') else ' '
-            arg_fmt = lambda t, n: f"{t}{pad_type(t)}{n}"
+            def pad_type(t): return '' if len(t) == 0 or t.endswith('*') or t.endswith('&') else ' '
+            def arg_fmt(t, n): return f'{t}{pad_type(t)}{n}'
             args = ', '.join([arg_fmt(t, n) for t, n in self._args])
 
         header = self._fmt.format(domain=domain, name=name, ttype=ttype,

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -147,7 +147,7 @@ def _comment_extract(tu):
     comments = {}
     current_comment = None
 
-    is_doc = lambda cursor: cursor and docstring.Docstring.is_doc(cursor.spelling)
+    def is_doc(cursor): return cursor and docstring.Docstring.is_doc(cursor.spelling)
 
     for token in tu.get_tokens(extent=tu.cursor.extent):
         # Handle all comments we come across.

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -100,7 +100,7 @@ class ParserTestcase(testenv.Testcase):
                     continue
 
                 transform = directive.options.get('transform')
-                process_docstring = lambda lines: _process_docstring(transform, lines)
+                def process_docstring(lines): return _process_docstring(transform, lines)
 
                 for docstrings in root.walk(recurse=False, filter_types=_filter_types(directive),
                                             filter_names=_filter_names(directive)):


### PR DESCRIPTION
PEP8 https://peps.python.org/pep-0008/ says:

Always use a def statement instead of an assignment statement that binds a lambda expression directly to an identifier.

Fix them, and drop the flake8 exception.