### PR TITLE
Type hints

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -29,6 +29,17 @@ jobs:
       - name: reStructuredText check
         run: make check-rst
 
+  typing:
+    name: Check typing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Type check
+        run: |
+          . venv
+          make check-typing
+
   examples:
     name: Check examples
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Unreleased `master`_
 
 :Date: YYYY-MM-DD
 
+Changed
+~~~~~~~
+
+* Bumped Python dependency requirement to v3.9, as v3.8 is reaching end of life
+
 Hawkmoth `0.18.0`_
 ------------------
 

--- a/Makefile.local
+++ b/Makefile.local
@@ -6,11 +6,15 @@ RST := $(RST) CHANGELOG.rst CONTRIBUTING.rst README.rst
 
 # Static analysis
 .PHONY: check
-check: check-style check-rst check-examples
+check: check-style check-typing check-rst check-examples
 
 .PHONY: check-style
 check-style:
 	flake8 src/hawkmoth test
+
+.PHONY: check-typing
+check-typing:
+	mypy
 
 .PHONY: check-rst
 check-rst:

--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Dependencies
 
 Dependencies and their minimum versions:
 
-- Python 3.8
+- Python 3.9
 - Sphinx 3
 - Clang library 6
 - Python 3 Bindings for Clang library 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,13 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "flake8",
+    "mypy",
     "pytest",
     "pytest-cov",
     "pytest-xdist",
     "restructuredtext_lint",
     "strictyaml",
+    "types-docutils",
 ]
 
 [project.scripts]
@@ -67,6 +69,21 @@ exclude = [
 exclude = [
     "**/Makefile*",
 ]
+
+[tool.mypy]
+files = [
+    "src",
+    "test",
+]
+exclude = "(test/conf\\.py|test/update-examples\\.py)"
+
+[[tool.mypy.overrides]]
+module = "clang.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "strictyaml.*"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Hawkmoth - Sphinx Autodoc for C"
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = {text = "BSD-2-Clause"}
-requires-python = "~=3.8"
+requires-python = "~=3.9"
 authors = [
     {name = "Jani Nikula", email = "jani@nikula.org"},
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 flake8
+mypy
 pytest
 pytest-cov
 pytest-xdist
 restructuredtext_lint
 sphinx
 strictyaml
+types-docutils

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -35,8 +35,8 @@ class _AutoBaseDirective(SphinxDirective):
     }
     has_content = False
 
-    _domain = None
-    _docstring_types = None
+    _domain: str | None = None
+    _docstring_types: list[type[docstring.Docstring]] | None = None
 
     def __display_parser_diagnostics(self, errors):
         # Map parser diagnostic level to Sphinx level name

--- a/src/hawkmoth/ext/javadoc/__init__.py
+++ b/src/hawkmoth/ext/javadoc/__init__.py
@@ -86,7 +86,7 @@ class _block_with_end_command(_handler):
     """Paragraph with a dedicated command to end it.
 
     For example, @code/@endcode."""
-    _end_command = None
+    _end_command: str | None = None
 
     def end_command(self):
         """Get the name of the command that ends this paragraph."""
@@ -135,7 +135,7 @@ class _strip_command(_handler):
 
 class _field_list(_handler):
     """Paragraph which becomes a single field list item."""
-    _field_name = None
+    _field_name: str | None = None
     _indented_paragraph = True
 
     def field_name(self):


### PR DESCRIPTION
Add the facility to use and check type hints. Add minimal type hints for now to make `mypy` pass, this is just the infrastructure. Also some minor static analysis make target shuffling.

I'm not sure if we should go all in on type hints, but perhaps it would be helpful to make it possible to add some useful type hints, as a start?
