### PR TITLE
build: bump python dependency to 3.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Unreleased `master`_
 
 :Date: YYYY-MM-DD
 
+Changed
+~~~~~~~
+
+* Bumped Python dependency requirement to v3.8, as the earlier versions have
+  reached end of life
+
 Hawkmoth `0.17.0`_
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Dependencies
 
 Dependencies and their minimum versions:
 
-- Python 3.6
+- Python 3.8
 - Sphinx 3
 - Clang library 6
 - Python 3 Bindings for Clang library 6

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
     Topic :: Software Development :: Documentation
 
 [options]
-python_requires = ~=3.6
+python_requires = ~=3.8
 install_requires =
     sphinx >= 3
     # clang, depend on distro packaging


### PR DESCRIPTION
Python 3.6 and 3.7 have reached end of life [1].

[1] https://devguide.python.org/versions/
