### PR TITLE
parser: fix linkage spec detection

### DIFF
--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-2023 Jani Nikula <jani@nikula.org>
-# Copyright (c) 2018-2023 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
+# Copyright (c) 2018-2024 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 
 from clang.cindex import (
@@ -146,10 +146,11 @@ class DocCursor:
         """Get children cursors."""
         domain = self.domain
 
-        # Identify `extern "C"` blocks and change domain accordingly. For some
-        # reason, the Python bindings don't return the cursor kind LINKAGE_SPEC
-        # as one would expect, so we need to do it the hard way.
-        if domain == 'cpp' and self.kind == CursorKind.UNEXPOSED_DECL:
+        # Identify `extern "C"` blocks and change domain accordingly.
+        # Prior to Clang 18, the Python bindings don't return the cursor kind
+        # LINKAGE_SPEC as one would expect, so we need to do it the hard way.
+        if domain == 'cpp' and self.kind in [CursorKind.LINKAGE_SPEC,
+                                             CursorKind.UNEXPOSED_DECL]:
             tokens = self.get_tokens()
             ntoken = next(tokens, None)
             if ntoken and ntoken.spelling == 'extern':

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-2017 Jani Nikula <jani@nikula.org>
-# Copyright (c) 2018-2023 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
+# Copyright (c) 2018-2024 Bruno Santos <brunomanuelsantos@tecnico.ulisboa.pt>
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 """
 Documentation comment extractor
@@ -174,7 +174,8 @@ def _comment_extract(tu):
 
         # Cursors that are 1) never documented themselves, and 2) not allowed
         # between the comment and the actual cursor being documented.
-        if token_cursor.kind in [CursorKind.UNEXPOSED_DECL]:
+        if token_cursor.kind in [CursorKind.LINKAGE_SPEC,
+                                 CursorKind.UNEXPOSED_DECL]:
             if is_doc(current_comment):
                 top_level_comments.append(current_comment)
             current_comment = None
@@ -299,9 +300,9 @@ def _parse_undocumented_block(errors, cursor, nest):
 
     # Identify `extern "C"` and `extern "C++"` blocks and recursively parse
     # their contents.
-    # For some reason, the Python bindings don't return the cursor kind
+    # Prior to Clang 18, the Python bindings don't return the cursor kind
     # LINKAGE_SPEC as one would expect, so we need to do it the hard way.
-    if cursor.kind == CursorKind.UNEXPOSED_DECL:
+    if cursor.kind in [CursorKind.LINKAGE_SPEC, CursorKind.UNEXPOSED_DECL]:
         tokens = cursor.get_tokens()
         ntoken = next(tokens, None)
         if ntoken and ntoken.spelling == 'extern':


### PR DESCRIPTION
Clang 18 now issues the right cursor kind for `extern "C"` blocks, so we need to extend the detection code.

Fixes #235.

-->8--

This should reliably fix the detection of those blocks on all supported versions of Clang, but a few improvements might still be possible:

1. We should probably _not_ check for UNEXPOSED_DECL unless we are on pre-18 versions to keep it neater. This would require a version check on the libclang that is actually loaded.

2. It is unclear whether we can avoid token matching for v18+. In principle, if the cursor kind is LINKAGE_SPEC, the children cursors are in the C domain. But is that a guarantee or just a strong heuristic? If not, is there a way of checking without token matching?

3. We should come up with a way to systematically mark code portions that need to be revisited as we update minimum requirements and such to avoid dead code. I can only think of another instance where we might want to do something along those lines (anonymous symbol handling), but I think it may be good to think about this soon-ish rather than later just in case more cases pop up.