### PR TITLE
Macro named variable argument

### DIFF
--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -283,9 +283,10 @@ class DocCursor:
         tokens = self.get_tokens()
 
         # Use the first two tokens to make sure this starts with 'IDENTIFIER('
-        one = next(tokens)
-        two = next(tokens, None)
-        if two is None or one.extent.end != two.extent.start or two.spelling != '(':
+        # *without* a space before the paren.
+        identifier = next(tokens)
+        paren = next(tokens, None)
+        if paren is None or identifier.extent.end != paren.extent.start or paren.spelling != '(':
             return None
 
         # Naïve parsing of macro arguments

--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -290,17 +290,19 @@ class DocCursor:
             return None
 
         # Naïve parsing of macro arguments
-        # FIXME: This doesn't handle GCC named vararg extension FOO(vararg...)
         args = []
+        arg_spellings = []
         for token in tokens:
-            if token.spelling == ')':
-                return args
-            elif token.spelling == ',':
+            if token.spelling in [')', ',']:
+                if arg_spellings:
+                    args.extend([('', ''.join(arg_spellings))])
+                    arg_spellings = []
+
+                if token.spelling == ')':
+                    return args
                 continue
-            elif token.kind == TokenKind.IDENTIFIER:
-                args.extend([('', token.spelling)])
-            elif token.spelling == '...':
-                args.extend([('', token.spelling)])
+            elif token.kind == TokenKind.IDENTIFIER or token.spelling == '...':
+                arg_spellings.append(token.spelling)
             else:
                 break
 

--- a/test/c/function-like-macro.c
+++ b/test/c/function-like-macro.c
@@ -7,3 +7,23 @@
  * Another
  */
 #define BAR() yeah
+
+/**
+ * Standard vararg.
+ */
+#define VARARG0(...) __VA_ARGS__
+
+/**
+ * Named argument and standard varargs.
+ */
+#define VARARG1(par0, ...) __VA_ARGS__
+
+/**
+ * Named varargs.
+ */
+#define VARARG0_NAMED(named...) named
+
+/**
+ * Named argument and named varargs.
+ */
+#define VARARG1_NAMED(par0, named...) named

--- a/test/c/function-like-macro.rst
+++ b/test/c/function-like-macro.rst
@@ -8,3 +8,23 @@
 
    Another
 
+
+.. c:macro:: VARARG0(...)
+
+   Standard vararg.
+
+
+.. c:macro:: VARARG1(par0, ...)
+
+   Named argument and standard varargs.
+
+
+.. c:macro:: VARARG0_NAMED(named...)
+
+   Named varargs.
+
+
+.. c:macro:: VARARG1_NAMED(par0, named...)
+
+   Named argument and named varargs.
+

--- a/test/cpp/function-like-macro.rst
+++ b/test/cpp/function-like-macro.rst
@@ -8,3 +8,23 @@
 
    Another
 
+
+.. c:macro:: VARARG0(...)
+
+   Standard vararg.
+
+
+.. c:macro:: VARARG1(par0, ...)
+
+   Named argument and standard varargs.
+
+
+.. c:macro:: VARARG0_NAMED(named...)
+
+   Named varargs.
+
+
+.. c:macro:: VARARG1_NAMED(par0, named...)
+
+   Named argument and named varargs.
+


### PR DESCRIPTION
Add support for the named variable argument in variadic macros i.e. `FOO(arg...)` style, and remove a long standing FIXME comment.

https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html