### PR TITLE
really drop python<=3.7 support.

### DIFF
--- a/src/hawkmoth/util/compiler.py
+++ b/src/hawkmoth/util/compiler.py
@@ -42,7 +42,7 @@ def _get_include_paths(cc_path):
     return _get_paths_from_output(result.stderr)
 
 def get_include_args(cc_path='clang'):
-    return ['-I{path}'.format(path=path) for path in _get_include_paths(cc_path)]
+    return [f'-I{path}' for path in _get_include_paths(cc_path)]
 
 if __name__ == '__main__':
     import pprint

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -79,7 +79,7 @@ class Testcase:
 
     def __init__(self, filename):
         self.filename = filename
-        with open(filename, 'r') as f:
+        with open(filename) as f:
             self.options = strictyaml.load(f.read(), self._options_schema).data
         self.testid = os.path.splitext(os.path.relpath(self.filename, testdir))[0]
 
@@ -131,5 +131,5 @@ def read_file(filename, optional=False):
 
     assert os.path.isfile(filename)
 
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         return f.read()

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -43,7 +43,7 @@ The ``[source]`` links are optional, and can be enabled via the
 ''')
 
 def print_title(testcases):
-    titles = set(get_title(testcase) for testcase in testcases if get_title(testcase))
+    titles = {get_title(testcase) for testcase in testcases if get_title(testcase)}
     title = ', '.join(sorted(titles))
 
     print(f'''{title}


### PR DESCRIPTION
Filter all code oved `pyupgrade --py38-plus`.