### PR TITLE
javadoc: allow space before parameter direction indication

### DIFF
--- a/src/hawkmoth/ext/javadoc/__init__.py
+++ b/src/hawkmoth/ext/javadoc/__init__.py
@@ -159,11 +159,12 @@ class _param(_field_list):
     _field_name = 'param'
 
     def header(self):
-        mo = re.match(r'^(\[(?P<direction>[a-zA-Z, ]+)\])?(?P<sp1>\s*)(?P<name>([a-zA-Z0-9_]+|\.\.\.))(?P<sp2>\s*(?P<desc>.*))',  # noqa: E501
+        mo = re.match(r'^((?P<sp0>\s*)\[(?P<direction>[a-zA-Z, ]+)\])?(?P<sp1>\s*)(?P<name>([a-zA-Z0-9_]+|\.\.\.))(?P<sp2>\s*(?P<desc>.*))',  # noqa: E501
                       self.rest())
         if mo is None:
             # FIXME
             yield ''
+            return
 
         direction = mo.group('direction')
         name = mo.group('name')


### PR DESCRIPTION
Having whitespace between @param and [direction] fails to match the param regex:

 @param[in] works
 @param [in] fails

This is detected but not handled properly, leading to a backtrace about mo.group() being called when mo is None.

Fix the regex and, to an extent, the error handling.

This is just the simplest and quickest fix. There should be better error handling with proper error messages all around, as well as testing.