### PR TITLE
Basic C++ namespace support

### DIFF
--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -535,7 +535,12 @@ class DocCursor:
             if child._cc.kind == CursorKind.CXX_BASE_SPECIFIER:
                 def pad(s): return s + ' ' if s else ''
                 access_spec = child._get_access_specifier()
-                inherited.append(f'{pad(access_spec)}{child._cc.type.spelling}')
+                if child._cc.referenced.kind == CursorKind.CLASS_DECL:
+                    # use referenced type if possible for full namespace
+                    spelling = child._cc.referenced.type.spelling
+                else:
+                    spelling = child._cc.type.spelling
+                inherited.append(f'{pad(access_spec)}{spelling}')
 
         return ': ' + ', '.join(inherited) if len(inherited) > 0 else None
 

--- a/src/hawkmoth/doccursor.py
+++ b/src/hawkmoth/doccursor.py
@@ -14,6 +14,23 @@ from clang.cindex import (
 )
 
 
+def _get_semantic_parent_namespace(cursor, namespace):
+    semantic_parent = cursor.semantic_parent
+    if not semantic_parent:
+        return namespace
+
+    if semantic_parent.kind == CursorKind.NAMESPACE:
+        # parent is a namespace => add namespace in front
+        if namespace is not None:
+            namespace = f'{semantic_parent.spelling}::{namespace}'
+        else:
+            namespace = semantic_parent.spelling
+        # check again for nested namespaces
+        return _get_semantic_parent_namespace(semantic_parent, namespace)
+
+    return namespace
+
+
 class DocCursor:
     """Documentation centric wrapper for Clang's own ``Cursor``.
 
@@ -66,7 +83,7 @@ class DocCursor:
 
     @property
     def name(self):
-        return self._cc.spelling if self._cc.spelling else self.decl_name
+        return self.namespace_prefix + self._cc.spelling if self._cc.spelling else self.decl_name
 
     @property
     def decl_name(self):
@@ -81,7 +98,14 @@ class DocCursor:
             return self._type_definition_fixup()
         else:
             # self.name would recurse back here if self._cc.spelling is None
-            return self._cc.spelling
+            return self.namespace_prefix + self._cc.spelling if self._cc.spelling else None
+
+    @property
+    def namespace_prefix(self):
+        if self.domain != 'cpp':
+            return ''
+        namespace = _get_semantic_parent_namespace(self._cc, None)
+        return f'{namespace}::' if namespace else ''
 
     @property
     def type(self):
@@ -271,7 +295,7 @@ class DocCursor:
         template = self._get_template_line()
         template = template + ' ' if template else ''
 
-        return f'{template}{self._cc.spelling}{colon_suffix}'
+        return f'{template}{self.namespace_prefix}{self._cc.spelling}{colon_suffix}'
 
     def _get_macro_args(self):
         """Get macro arguments.

--- a/src/hawkmoth/parser.py
+++ b/src/hawkmoth/parser.py
@@ -322,6 +322,17 @@ def _parse_undocumented_block(errors, cursor, nest):
                 if c.comment:
                     ret.extend(_recursive_parse(errors, c, nest))
 
+    elif cursor.kind == CursorKind.NAMESPACE:
+        # ignore internal STL namespaces
+        if cursor.name in ['std', '__gnu_cxx', '__cxxabiv1', '__gnu_debug']:
+            return ret
+        # iterate over namespace
+        for c in cursor.get_children():
+            if c.comment:
+                ret.extend(_recursive_parse(errors, c, nest))
+            else:
+                ret.extend(_parse_undocumented_block(errors, c, nest))
+
     return ret
 
 def _language_option(filename, domain):

--- a/test/cpp/namespace.cpp
+++ b/test/cpp/namespace.cpp
@@ -1,0 +1,99 @@
+namespace A {
+	namespace B {
+
+		/**
+		 * Test fct A
+		 */
+		int testa(int a) { return a; }
+
+		/**
+		 * Test cls B
+		 */
+		class TestB {
+		public:
+			/**
+			 * Test fct B
+			 */
+			int testb(int b) { return b; }
+
+		private:
+			/** Not constant */
+			double b;
+		};
+
+
+		/** Some constant */
+		constexpr double CONSTANT = 5.;
+
+	} // namespace B
+
+	/**
+	 * Test cls D
+	 */
+	class TestD : public B::TestB {
+	public:
+		/**
+		 * Test fct D
+		 */
+		int testd() const { return d; }
+	private:
+		static double d;
+	};
+
+	/**
+	 * Test fct C
+	 */
+	template<typename T>
+	int testc(int c) { return c; }
+
+	/**
+	 * Test enum E
+	 */
+	enum class TestE {
+		/** enum member A */
+		A,
+		/** enum member B */
+		B,
+	};
+
+} // namespace A
+
+
+namespace foo {
+	/**
+	 * foo_class
+	 */
+	class foo_class {
+		/** member */
+		int m;
+	};
+
+	/**
+	 * foo_struct
+	 */
+	struct foo_struct {
+		/** member */
+		int m;
+	};
+
+	/**
+	 * foo_union
+	 */
+	union foo_union {
+		/** member1 */
+		int m1;
+		/** member2 */
+		int m2;
+	};
+
+	/**
+	 * Const.
+	 */
+	const int GLOBAL = 5;
+
+	/** enum */
+	enum foo_enum {
+		/** enumerator */
+		FOO_ENUMERATOR,
+	};
+};

--- a/test/cpp/namespace.rst
+++ b/test/cpp/namespace.rst
@@ -1,0 +1,105 @@
+
+.. cpp:function:: int A::B::testa(int a)
+
+   Test fct A
+
+
+.. cpp:class:: A::B::TestB
+
+   Test cls B
+
+
+   .. cpp:function:: public int testb(int b)
+
+      Test fct B
+
+
+   .. cpp:member:: private double b
+
+      Not constant
+
+
+.. cpp:var:: constexpr double CONSTANT
+
+   Some constant
+
+
+.. cpp:class:: A::TestD: public A::B::TestB
+
+   Test cls D
+
+
+   .. cpp:function:: public int testd(void) const
+
+      Test fct D
+
+
+.. cpp:function:: template<typename T> int A::testc(int c)
+
+   Test fct C
+
+
+.. cpp:enum-class:: A::TestE
+
+   Test enum E
+
+
+   .. cpp:enumerator:: A
+
+      enum member A
+
+
+   .. cpp:enumerator:: B
+
+      enum member B
+
+
+.. cpp:class:: foo::foo_class
+
+   foo_class
+
+
+   .. cpp:member:: private int m
+
+      member
+
+
+.. cpp:struct:: foo::foo_struct
+
+   foo_struct
+
+
+   .. cpp:member:: public int m
+
+      member
+
+
+.. cpp:union:: foo::foo_union
+
+   foo_union
+
+
+   .. cpp:member:: int m1
+
+      member1
+
+
+   .. cpp:member:: int m2
+
+      member2
+
+
+.. cpp:var:: const int GLOBAL
+
+   Const.
+
+
+.. cpp:enum:: foo::foo_enum
+
+   enum
+
+
+   .. cpp:enumerator:: FOO_ENUMERATOR
+
+      enumerator
+

--- a/test/cpp/namespace.yaml
+++ b/test/cpp/namespace.yaml
@@ -1,0 +1,6 @@
+directives:
+- domain: cpp
+  directive: autodoc
+  arguments:
+  - namespace.cpp
+expected: namespace.rst


### PR DESCRIPTION
This incorporates @stephanlachnit's work from #211 and adds some tests on top.

Let's be honest, there are still some gaps here. For example, variables within a namespace don't get the namespace prefix in documentation. However, I'm making the argument this is a net positive improvement over the status quo, regardless of those gaps. This is progress. This can be built upon.

The tests added merely check against the current output, not what might be the desired output. I don't even have enough recent experience on modern C++ to say what the desired prefixing would be.

Anyway, unless @stephanlachnit and @BrunoMSantos are vehemently opposed, I'm going to merge this as-is.

Let's just move things forward.
