### PR TITLE
doc: remove notes about C++ gaps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,12 +37,6 @@ documentation, and more. In short, Hawkmoth is Sphinx Autodoc for C/C++.
 Hawkmoth aims to be a compelling alternative for documenting C and C++ projects
 using Sphinx, mainly through its simplicity of design, implementation and use.
 
-**Note**
-
-   The C++ support is still in early stages of development, and lacks some
-   fundamental features such as handling namespaces and documenting C++ specific
-   features other than classes.
-
 .. _Sphinx: http://www.sphinx-doc.org
 
 .. _C and C++ Domain: http://www.sphinx-doc.org/en/stable/domains.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,12 +11,6 @@ Sphinx Autodoc for C/C++.
 Hawkmoth aims to be a compelling alternative for documenting C and C++ projects
 using Sphinx, mainly through its simplicity of design, implementation and use.
 
-.. note::
-
-   The C++ support is still in early stages of development, and lacks some
-   fundamental features such as handling namespaces and documenting C++ specific
-   features other than classes.
-
 Please see the `Hawkmoth project GitHub page`_ (or README.rst in the source
 repository) for information on how to obtain, install, and contribute to
 Hawkmoth, as well as how to contact the developers.


### PR DESCRIPTION
While there may still be gaps with the C++ support, we do have the most common cases covered, and don't want to scare away potential users.