### PR TITLE
test: combine the asserts for output and errors

### DIFF
--- a/test/testenv.py
+++ b/test/testenv.py
@@ -104,8 +104,7 @@ class Testcase:
 
         assert output_docs, 'empty output'
         assert expect_docs, 'empty expected'
-        assert output_docs == expect_docs
-        assert output_errors == expect_errors
+        assert output_docs + output_errors == expect_docs + expect_errors
 
 def get_testid(testcase):
     return testcase.get_testid()


### PR DESCRIPTION
With the output and error asserts separate, the test case ends on the first failing assertion, and we never know what was in errors. But the clue to the output mismatch might be in the errors. For example, an include file was not found. By combining the asserts into one, we get all the differences in the pytest results.
