### PR TITLE
test: define default clang args for testing

### DIFF
--- a/test/cpp/template.yaml
+++ b/test/cpp/template.yaml
@@ -3,7 +3,4 @@ directives:
   directive: autodoc
   arguments:
   - template.cpp
-  options:
-    clang:
-    - --std=c++17
 expected: template.rst

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -30,11 +30,19 @@ class Directive:
 
         return self.testcase.get_relative_filename(basename)
 
-    def get_directive_string(self):
+    def get_directive_string(self, example=False):
         arguments_str = ' '.join(self.arguments)
         directive_str = f'.. {self.domain}:{self.directive}:: {arguments_str}\n'
 
-        for key, value in self.options.items():
+        if example:
+            # Use the options verbatim in documenting the examples.
+            options = self.options
+        else:
+            # Insert the default clang args for testing.
+            options = self.options.copy()
+            options['clang'] = self.get_clang_args()
+
+        for key, value in options.items():
             if isinstance(value, list):
                 value = ', '.join(value)
             space = ' ' if len(value) else ''
@@ -42,8 +50,16 @@ class Directive:
 
         return directive_str
 
+    def _get_default_clang_args(self):
+        if self.domain == 'c':
+            return ['-std=c17']
+        else:
+            return ['-std=c++17']
+
     def get_clang_args(self):
         clang_args = []
+
+        clang_args.extend(self._get_default_clang_args())
 
         clang_args.extend(self.options.get('clang', []))
 

--- a/test/update-examples.py
+++ b/test/update-examples.py
@@ -85,7 +85,7 @@ def print_example(testcase):
         namespace_push = ''
         namespace_pop = ''
 
-    directive_str = testcase.directives[0].get_directive_string()
+    directive_str = testcase.directives[0].get_directive_string(example=True)
 
     print(f'''Directive
 ~~~~~~~~~


### PR DESCRIPTION
For starters, define the language stardard to use. Use c17 and c++17, fairly arbitrarily. Tests can override this. We can remove the std option from template.yaml.

This is a bit more convoluted than should be necessary, for a few reasons:

- Extension tests use the directive options from directive string. For that, the defaults should be specified in conf.py, but hawkmoth_clang is not domain specific, and can't be used. See [1]. We need to insert the defaults in directive options.

- We want to preserve the original directive options, and present those in examples documentation. However, in all testing, we need to amend the defaults.

Note that the parser selects the -x language option based on domain and filename suffix.

[1] https://github.com/jnikula/hawkmoth/issues/255