### PR TITLE
test: rename test_cautodoc.py -> test_extension.py

### DIFF
--- a/test/README.rst
+++ b/test/README.rst
@@ -22,8 +22,8 @@ There are three test files, with different levels and approaches, run by
   Test the parser and the command-line interface. The documentation comments are
   extracted through the command-line interface.
 
-* ``test_directive_text()`` and ``test_directive_html()`` in
-  ``test_cautodoc.py``
+* ``test_extension_text()`` and ``test_extension_html()`` in
+  ``test_extension.py``
 
   Test the parser and the Sphinx extension, using two builders: text and
   html. The documentation comments are extracted through the Sphinx build

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -88,12 +88,12 @@ def _get_extension_testcases(path, buildername):
 # Test using Sphinx plain text builder
 @pytest.mark.parametrize('testcase', _get_extension_testcases(testenv.testdir, 'text'),
                          ids=testenv.get_testid)
-def test_directive_text(testcase):
+def test_extension_text(testcase):
     testcase.run_test()
 
 # Test using Sphinx html builder
 @pytest.mark.full
 @pytest.mark.parametrize('testcase', _get_extension_testcases(testenv.testdir, 'html'),
                          ids=testenv.get_testid)
-def test_directive_html(testcase):
+def test_extension_html(testcase):
     testcase.run_test()


### PR DESCRIPTION
cautodoc is a remnant from the past. This module tests the extension, name it accordingly.

Also rename the test methods to reflect the same.