### PR TITLE
Domain specific clang args

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Unreleased `master`_
 
 :Date: YYYY-MM-DD
 
+Added
+~~~~~
+
+* Domain specific config options ``hawkmoth_clang_c`` and
+  ``hawkmoth_clang_cpp``.
+
 Changed
 ~~~~~~~
 

--- a/doc/Makefile.local
+++ b/doc/Makefile.local
@@ -16,7 +16,7 @@ CLEAN := $(CLEAN) $(BUILDDIR)
 
 .PHONY: update-examples
 update-examples:
-	$(test_dir)/update-examples.py > $(doc_dir)/examples.rst
+	python3 -m $(test_dir).update_examples > $(doc_dir)/examples.rst
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -85,6 +85,18 @@ See also additional configuration options in the :ref:`built-in extensions
    You can also pass in the compiler to use, for example
    ``get_include_args('gcc')``.
 
+.. py:data:: hawkmoth_clang_c
+   :type: list
+
+   Arguments to pass to ``clang`` after :data:`hawkmoth_clang` in the C domain
+   only.
+
+.. py:data:: hawkmoth_clang_cpp
+   :type: list
+
+   Arguments to pass to ``clang`` after :data:`hawkmoth_clang` in the C++ domain
+   only.
+
 .. py:data:: hawkmoth_source_uri
    :type: str
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,11 +71,16 @@ exclude = [
 ]
 
 [tool.mypy]
-files = [
-    "src",
+mypy_path = "src:."
+packages = [
+    "hawkmoth",
     "test",
 ]
 exclude = "(test/conf\\.py)"
+
+[[tool.mypy.overrides]]
+module = "test.*"
+follow_imports = "skip"
 
 [[tool.mypy.overrides]]
 module = "clang.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ files = [
     "src",
     "test",
 ]
-exclude = "(test/conf\\.py|test/update-examples\\.py)"
+exclude = "(test/conf\\.py)"
 
 [[tool.mypy.overrides]]
 module = "clang.*"

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -57,6 +57,11 @@ class _AutoBaseDirective(SphinxDirective):
 
         clang_args.extend(self.env.config.hawkmoth_clang.copy())
 
+        if self._domain == 'c':
+            clang_args.extend(self.env.config.hawkmoth_clang_c.copy())
+        else:
+            clang_args.extend(self.env.config.hawkmoth_clang_cpp.copy())
+
         clang_args.extend(self.options.get('clang', []))
 
         return clang_args
@@ -353,6 +358,8 @@ def setup(app):
 
     app.add_config_value('hawkmoth_root', app.confdir, 'env', [str])
     app.add_config_value('hawkmoth_clang', [], 'env', [list])
+    app.add_config_value('hawkmoth_clang_c', [], 'env', [list])
+    app.add_config_value('hawkmoth_clang_cpp', [], 'env', [list])
 
     app.add_config_value('hawkmoth_transform_default', None, 'env', [str])
 

--- a/test/Makefile.local
+++ b/test/Makefile.local
@@ -17,7 +17,7 @@ test-verbose:
 # Ensure a) update-examples works, and b) examples have been updated.
 .PHONY: check-examples
 check-examples:
-	$(test_dir)/update-examples.py | diff -u $(doc_dir)/examples.rst -
+	python3 -m $(test_dir).update_examples | diff -u $(doc_dir)/examples.rst -
 
 .PHONY: quick-test
 quick-test:

--- a/test/README.rst
+++ b/test/README.rst
@@ -56,7 +56,7 @@ Test Cases as Examples
 The examples in the documentation are generated from test cases under the
 ``examples`` subdirectory, ensuring the examples actually work.
 
-``make update-examples`` runs ``update-examples.py`` to generate
+``make update-examples`` runs ``update_examples.py`` to generate
 ``doc/examples.rst`` from the example test cases.
 
 Running

--- a/test/conf.py
+++ b/test/conf.py
@@ -29,6 +29,11 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
+# -- Options for Hawkmoth ----------------------------------------------------
+# https://jnikula.github.io/hawkmoth/dev/extension.html#configuration
+
+hawkmoth_clang_c = ['-std=c17']
+hawkmoth_clang_cpp = ['-std=c++17']
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/test/cpp/template.yaml
+++ b/test/cpp/template.yaml
@@ -3,7 +3,4 @@ directives:
   directive: autodoc
   arguments:
   - template.cpp
-  options:
-    clang:
-    - --std=c++17
 expected: template.rst

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -7,6 +7,8 @@ import sys
 import pytest
 import strictyaml
 
+from test import conf
+
 testext = '.yaml'
 testdir = os.path.dirname(os.path.abspath(__file__))
 rootdir = os.path.dirname(testdir)
@@ -43,7 +45,12 @@ class Directive:
         return directive_str
 
     def get_clang_args(self):
-        clang_args = []
+        clang_args = getattr(conf, 'hawkmoth_clang', [])
+
+        if self.domain == 'c':
+            clang_args.extend(getattr(conf, 'hawkmoth_clang_c', []))
+        else:
+            clang_args.extend(getattr(conf, 'hawkmoth_clang_cpp', []))
 
         clang_args.extend(self.options.get('clang', []))
 

--- a/test/update_examples.py
+++ b/test/update_examples.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 
-import testenv
+from test import testenv
 
 class ExampleTestcase(testenv.Testcase):
     pass


### PR DESCRIPTION
Fix #255 and specify C and C++ standard to use for tests.

Importing conf.py in tests requires some changes in update-examples and mypy.
 