### PR TITLE
typing: use Optional[T] instead of T | None for Python 3.9 compatibility

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -9,6 +9,7 @@ Sphinx C Domain autodoc directive extension.
 
 import glob
 import os
+from typing import Optional
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -35,8 +36,8 @@ class _AutoBaseDirective(SphinxDirective):
     }
     has_content = False
 
-    _domain: str | None = None
-    _docstring_types: list[type[docstring.Docstring]] | None = None
+    _domain: Optional[str] = None
+    _docstring_types: Optional[list[type[docstring.Docstring]]] = None
 
     def __display_parser_diagnostics(self, errors):
         # Map parser diagnostic level to Sphinx level name

--- a/src/hawkmoth/ext/javadoc/__init__.py
+++ b/src/hawkmoth/ext/javadoc/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the terms of BSD 2-Clause, see LICENSE for details.
 
 import re
+from typing import Optional
 
 # The "operator" character, either \ or @, but not escaped with \
 OP = r'(?<!\\)(?P<op>[\\@])'
@@ -86,7 +87,7 @@ class _block_with_end_command(_handler):
     """Paragraph with a dedicated command to end it.
 
     For example, @code/@endcode."""
-    _end_command: str | None = None
+    _end_command: Optional[str] = None
 
     def end_command(self):
         """Get the name of the command that ends this paragraph."""
@@ -135,7 +136,7 @@ class _strip_command(_handler):
 
 class _field_list(_handler):
     """Paragraph which becomes a single field list item."""
-    _field_name: str | None = None
+    _field_name: Optional[str] = None
     _indented_paragraph = True
 
     def field_name(self):


### PR DESCRIPTION
Although Python 3.9 supports built-in type hinting instead of having to import from typing, unfortunately the T | None syntax was only introduced in Python 3.10.

Use Optional[T] instead for Python 3.9 compatibility.