### PR TITLE
Fix include paths

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+      - name: Install dependencies (apt)
+        run: sudo apt-get install -y python3-clang python3-pip
       - name: Examples check
         run: |
           . venv

--- a/doc/extension.rst
+++ b/doc/extension.rst
@@ -56,9 +56,38 @@ See also additional configuration options in the :ref:`built-in extensions
    :type: str
 
    The default transform parameter to be passed to the
-   :event:`hawkmoth-process-docstring` event. It can be overriden with the
+   :event:`hawkmoth-process-docstring` event. It can be overridden with the
    ``transform`` option of the :ref:`directives <directives>`. Defaults to
    ``None``.
+
+.. py:data:: hawkmoth_compiler
+   :type: str
+
+   The (path to the) default compiler used by the project. This is used to
+   determine the exact options needed to parse the code files by libclang
+   provided the relevant options are enabled in :data:`hawkmoth_autoconf`.
+
+   Notably, it allows hawkmoth to override libclang's default search path for
+   system headers with those of the specified compiler.
+
+   This presumes the compiler supports being called as
+   ``<compiler> -x <c|c++> -E -Wp,-v /dev/null``.
+
+   Defaults to ``clang``, which may differ from libclang's own default includes.
+   It will use libclang's defaults if set to ``None`` though.
+
+.. py:data:: hawkmoth_autoconf
+   :type: list
+
+   List of options that control the automatic configuration features of
+   hawkmoth. Currently supported options:
+
+   * ``'stdinc'``: override the standard include paths of libclang with those of
+     the specified compiler (see :data:`hawkmoth_compiler`).
+
+     This is a shortcut to specify ``-nostdinc -I<dir 1> ... -I<dir n>`` in
+     :data:`hawkmoth_clang` with the search directories of the specified
+     compiler.
 
 .. py:data:: hawkmoth_clang
    :type: list
@@ -72,18 +101,6 @@ See also additional configuration options in the :ref:`built-in extensions
    .. code-block:: python
 
       hawkmoth_clang = ['-I/path/to/include', '-DHAWKMOTH']
-
-   Hawkmoth provides a convenience helper for querying the include path from the
-   compiler, and providing them as ``-I`` options:
-
-   .. code-block:: python
-
-      from hawkmoth.util import compiler
-
-      hawkmoth_clang = compiler.get_include_args()
-
-   You can also pass in the compiler to use, for example
-   ``get_include_args('gcc')``.
 
 .. py:data:: hawkmoth_clang_c
    :type: list

--- a/test/c/autoconf-invalid.stderr
+++ b/test/c/autoconf-invalid.stderr
@@ -1,0 +1,1 @@
+WARNING: autoconf: ['invalid'] unsupported option(s) ignored

--- a/test/c/autoconf-invalid.yaml
+++ b/test/c/autoconf-invalid.yaml
@@ -1,0 +1,12 @@
+test:
+- extension
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
+  - doc.c
+conf-overrides:
+  hawkmoth_autoconf:
+  - 'invalid'
+errors: autoconf-invalid.stderr
+expected: doc.rst

--- a/test/c/autoconf.yaml
+++ b/test/c/autoconf.yaml
@@ -1,0 +1,13 @@
+test:
+- extension
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
+  - bool.c
+conf-overrides:
+  hawkmoth_clang: -nostdinc
+  hawkmoth_compiler: clang
+  hawkmoth_autoconf:
+  - 'stdinc'
+expected: bool.rst

--- a/test/c/compiler-autoconf-mismatch.stderr
+++ b/test/c/compiler-autoconf-mismatch.stderr
@@ -1,0 +1,1 @@
+WARNING: autoconf: 'stdinc' option ignored (missing compiler)

--- a/test/c/compiler-autoconf-mismatch.yaml
+++ b/test/c/compiler-autoconf-mismatch.yaml
@@ -1,0 +1,13 @@
+test:
+- extension
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
+  - doc.c
+conf-overrides:
+  hawkmoth_compiler: null
+  hawkmoth_autoconf:
+  - 'stdinc'
+errors: compiler-autoconf-mismatch.stderr
+expected: doc.rst

--- a/test/c/compiler-not-found.stderr
+++ b/test/c/compiler-not-found.stderr
@@ -1,0 +1,2 @@
+WARNING: get_include_args: c compiler not found ('invalid')
+WARNING: get_include_args: c++ compiler not found ('invalid')

--- a/test/c/compiler-not-found.yaml
+++ b/test/c/compiler-not-found.yaml
@@ -1,0 +1,11 @@
+test:
+- extension
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
+  - doc.c
+conf-overrides:
+  hawkmoth_compiler: invalid
+errors: compiler-not-found.stderr
+expected: doc.rst

--- a/test/c/compiler-unknown.stderr
+++ b/test/c/compiler-unknown.stderr
@@ -1,0 +1,2 @@
+WARNING: get_include_args: incompatible c compiler ('false')
+WARNING: get_include_args: incompatible c++ compiler ('false')

--- a/test/c/compiler-unknown.yaml
+++ b/test/c/compiler-unknown.yaml
@@ -1,0 +1,11 @@
+test:
+- extension
+directives:
+- domain: c
+  directive: autodoc
+  arguments:
+  - doc.c
+conf-overrides:
+  hawkmoth_compiler: false
+errors: compiler-unknown.stderr
+expected: doc.rst

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -32,6 +32,10 @@ def _stderr_basename(errors_str):
 
 
 class CliTestcase(testenv.Testcase):
+
+    def valid(self):
+        return 'cli' in self.options.get('test', ['cli'])
+
     def set_monkeypatch(self, monkeypatch):
         self.monkeypatch = monkeypatch
         self.mock_args([])
@@ -88,7 +92,9 @@ class CliTestcase(testenv.Testcase):
 
 def _get_cli_testcases(path):
     for f in testenv.get_testcase_filenames(path):
-        yield CliTestcase(f)
+        testcase = CliTestcase(f)
+        if testcase.valid():
+            yield testcase
 
 @pytest.mark.full
 @pytest.mark.parametrize('testcase', _get_cli_testcases(testenv.testdir),

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -42,9 +42,6 @@ class ExtensionTestcase(testenv.Testcase):
                          doctreedir=doctreedir, buildername=self._buildername,
                          confoverrides=confoverrides, warning=warning)
 
-            # Ensure there are no errors with app creation.
-            assert warning.getvalue() == ''
-
             # Set root to the directory the testcase yaml is in, because the
             # filenames in yaml are relative to it.
             app.config.hawkmoth_root = os.path.dirname(self.filename)

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -20,6 +20,9 @@ class ExtensionTestcase(testenv.Testcase):
         super().__init__(filename)
         self._buildername = buildername
 
+    def valid(self):
+        return 'extension' in self.options.get('test', ['extension'])
+
     def _get_suffix(self):
         return 'txt' if self._buildername == 'text' else self._buildername
 
@@ -83,7 +86,9 @@ class ExtensionTestcase(testenv.Testcase):
 
 def _get_extension_testcases(path, buildername):
     for f in testenv.get_testcase_filenames(path):
-        yield ExtensionTestcase(f, buildername)
+        testcase = ExtensionTestcase(f, buildername)
+        if testcase.valid():
+            yield testcase
 
 # Test using Sphinx plain text builder
 @pytest.mark.parametrize('testcase', _get_extension_testcases(testenv.testdir, 'text'),

--- a/test/test_extension.py
+++ b/test/test_extension.py
@@ -30,6 +30,7 @@ class ExtensionTestcase(testenv.Testcase):
         outdir = os.path.join(srcdir, self._buildername)
         doctreedir = os.path.join(srcdir, 'doctrees')
         confdir = testenv.testdir
+        confoverrides = self.get_conf_overrides()
 
         # Don't emit color codes in Sphinx status/warning output
         console.nocolor()
@@ -39,7 +40,7 @@ class ExtensionTestcase(testenv.Testcase):
         with patch_docutils(confdir), docutils_namespace():
             app = Sphinx(srcdir=srcdir, confdir=confdir, outdir=outdir,
                          doctreedir=doctreedir, buildername=self._buildername,
-                         warning=warning)
+                         confoverrides=confoverrides, warning=warning)
 
             # Ensure there are no errors with app creation.
             assert warning.getvalue() == ''

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -58,6 +58,9 @@ def _filter_members(directive):
     return members
 
 class ParserTestcase(testenv.Testcase):
+    def valid(self):
+        return 'parser' in self.options.get('test', ['parser'])
+
     def get_output(self):
         roots = {}
         docs_str = ''
@@ -114,7 +117,9 @@ class ParserTestcase(testenv.Testcase):
 
 def _get_parser_testcases(path):
     for f in testenv.get_testcase_filenames(path):
-        yield ParserTestcase(f)
+        testcase = ParserTestcase(f)
+        if testcase.valid():
+            yield testcase
 
 @pytest.mark.parametrize('testcase', _get_parser_testcases(testenv.testdir),
                          ids=testenv.get_testid)

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -74,6 +74,9 @@ class Testcase:
                 strictyaml.Optional('transform'): strictyaml.Str(),
             }),
         })),
+        strictyaml.Optional('conf-overrides'): strictyaml.MapPattern(
+            strictyaml.Str(), strictyaml.NullNone() | strictyaml.EmptyList() | strictyaml.Any(),
+        ),
         strictyaml.Optional('expected-failure'): strictyaml.Bool(),
         strictyaml.Optional('example-use-namespace'): strictyaml.Bool(),
         strictyaml.Optional('example-title'): strictyaml.Str(),
@@ -107,6 +110,9 @@ class Testcase:
 
     def get_stderr_filename(self):
         return self.get_relative_filename(self.options.get('errors'))
+
+    def get_conf_overrides(self):
+        return self.options.get('conf-overrides', {})
 
     def run_test(self):
         if self.options.get('expected-failure'):

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -61,6 +61,7 @@ class Directive:
 
 class Testcase:
     _options_schema = strictyaml.Map({
+        strictyaml.Optional('test'): strictyaml.Seq(strictyaml.Str()),
         'directives': strictyaml.Seq(strictyaml.Map({
             'domain': strictyaml.Enum(['c', 'cpp']),
             'directive': strictyaml.Str(),
@@ -85,6 +86,8 @@ class Testcase:
         self.filename = filename
         with open(filename) as f:
             self.options = strictyaml.load(f.read(), self._options_schema).data
+            if self.options.get('test', None) is None:
+                self.options['test'] = ['cli', 'parser', 'extension']
         self.testid = os.path.splitext(os.path.relpath(self.filename, testdir))[0]
 
         self.directives = [Directive(self, directive_config) for

--- a/test/testenv.py
+++ b/test/testenv.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 import strictyaml
 
+from hawkmoth.util import compiler
 from test import conf
 
 testext = '.yaml'
@@ -49,10 +50,12 @@ class Directive:
 
         if self.domain == 'c':
             clang_args.extend(getattr(conf, 'hawkmoth_clang_c', []))
+            clang_args.extend(self.options.get('clang', []))
+            clang_args.extend(compiler.get_include_args('clang', 'c'))
         else:
             clang_args.extend(getattr(conf, 'hawkmoth_clang_cpp', []))
-
-        clang_args.extend(self.options.get('clang', []))
+            clang_args.extend(self.options.get('clang', []))
+            clang_args.extend(compiler.get_include_args('clang', 'c++'))
 
         return clang_args
 


### PR DESCRIPTION
So here's a possible (interim) solution which also solves a common problem for me at least: always having to specify `-nostdinc -I...` manually when playing around with cross compiled projects and so on.

This does not address the fact that the `clang` in the path might not be the one associated with the libclang we're using at any given moment, but does that matter? We're telling hawkmoth to parse these files with the headers used by compiler A, where A may not even be clang at all... Generally, libclang is meant to provide us with a parser, not code.

As for our tests... We don't really care I think: both the parser and our code snippets will work with any compliant headers, we just make a fair assumption that there's a clang binary in the path, which is quite fair except for mac perhaps (I didn't look into that, but should be a simple fix, no?).

What do you think @jnikula ?