### PR TITLE
Add Dockerfile for Arch Linux & use a more complicated WORKDIR

### DIFF
--- a/docker/Dockerfile.alpine-latest
+++ b/docker/Dockerfile.alpine-latest
@@ -10,7 +10,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.arch-latest
+++ b/docker/Dockerfile.arch-latest
@@ -1,0 +1,25 @@
+FROM archlinux:latest
+
+RUN pacman -Syu --noconfirm \
+    clang \
+    diffutils \
+    make \
+    python
+
+ARG UID=1000
+ARG GID=1000
+ARG ARCHIVE
+
+WORKDIR /src
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV PYTEST_ADDOPTS "-p no:cacheprovider"
+
+ADD ${ARCHIVE} .
+
+RUN sh venv
+
+ENV PATH=".venv/bin:${PATH}"
+
+USER ${UID}:${GID}

--- a/docker/Dockerfile.arch-latest
+++ b/docker/Dockerfile.arch-latest
@@ -10,7 +10,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.debian-bookworm
+++ b/docker/Dockerfile.debian-bookworm
@@ -13,7 +13,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.debian-bullseye
+++ b/docker/Dockerfile.debian-bullseye
@@ -13,7 +13,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.debian-trixie
+++ b/docker/Dockerfile.debian-trixie
@@ -13,7 +13,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.fedora-39
+++ b/docker/Dockerfile.fedora-39
@@ -12,7 +12,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.fedora-40
+++ b/docker/Dockerfile.fedora-40
@@ -12,7 +12,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.fedora-41
+++ b/docker/Dockerfile.fedora-41
@@ -12,7 +12,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.fedora-rawhide
+++ b/docker/Dockerfile.fedora-rawhide
@@ -12,7 +12,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Dockerfile.ubuntu-latest
+++ b/docker/Dockerfile.ubuntu-latest
@@ -13,7 +13,8 @@ ARG UID=1000
 ARG GID=1000
 ARG ARCHIVE
 
-WORKDIR /src
+# Make it harder for libclang to find headers by coincidence
+WORKDIR /path/to/src
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker/Makefile.local
+++ b/docker/Makefile.local
@@ -27,11 +27,17 @@ DOCKER_TEST_OUT_MOUNT = --mount type=bind,src=$(PWD)/doc/_build,dst=/out
 hawkmoth-test.%: $(HAWKMOTH_ARCHIVE) FORCE
 	docker build --file $(docker_dir)/Dockerfile$(suffix $@) --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) --build-arg ARCHIVE=$< --tag $@ .
 
+docker-test-all: $(foreach distro,$(DOCKER_DISTROS),docker-test.$(distro)) FORCE
+
 docker-test.%: hawkmoth-test.% FORCE
 	docker run $< make test
 
+docker-check-all: $(foreach distro,$(DOCKER_DISTROS),docker-check.$(distro)) FORCE
+
 docker-check.%: hawkmoth-test.% FORCE
 	docker run $< make check
+
+docker-html-all: $(foreach distro,$(DOCKER_DISTROS),docker-html.$(distro)) FORCE
 
 docker-html.%: hawkmoth-test.% FORCE
 	mkdir -p doc/_build

--- a/docker/Makefile.local
+++ b/docker/Makefile.local
@@ -19,6 +19,8 @@ $(HAWKMOTH_ARCHIVE): FORCE
 	@echo "error: git not available or not inside a git work tree" && false
 endif
 
+DOCKER_DISTROS := $(shell find $(docker_dir) -name 'Dockerfile.*' | sed 's/.*\.//' | sort)
+
 # Containers for local testing
 DOCKER_TEST_OUT_MOUNT = --mount type=bind,src=$(PWD)/doc/_build,dst=/out
 
@@ -36,7 +38,7 @@ docker-html.%: hawkmoth-test.% FORCE
 	docker run $(DOCKER_TEST_OUT_MOUNT) $< make BUILDDIR=/out html
 
 # Generate targets for auto-completion
-$(shell find $(docker_dir) -name 'Dockerfile.*' | sed 's/.*\.\(.*\)/docker-test.\1 docker-check.\1 docker-html.\1/'):
+$(foreach distro,$(DOCKER_DISTROS),docker-test.$(distro) docker-check.$(distro) docker-html.$(distro)):
 
 FORCE:
 


### PR DESCRIPTION
Add Dockerfile for running tests on Arch Linux (it's broken), and change WORKDIR to `/path/to/src` in all Dockerfiles (breaking Fedora docker testing in the process).

Turns out libclang can't find headers on either Arch Linux or Fedora. And it only worked by accident with our Fedora Docker images, because libclang on Fedora has some relative paths that just worked with `/src` as the current dir. Seriously. :facepalm: 

With #263 soon coming to the rescue, and fixing all of this (tested), highlight all the breakage.
