### PR TITLE
Use -isystem

### DIFF
--- a/src/hawkmoth/util/compiler.py
+++ b/src/hawkmoth/util/compiler.py
@@ -64,9 +64,13 @@ def get_include_args(cpath='clang', lang='c', cc_path=None):
     return ['-nostdinc'] + [f'-isystem{path}' for path in _get_include_paths(cpath, lang)]
 
 if __name__ == '__main__':
+    import argparse
     import pprint
-    import sys
 
-    compiler = sys.argv[1] if len(sys.argv) > 1 else 'clang'
+    parser = argparse.ArgumentParser()
+    parser.add_argument('compiler', nargs='?', default='clang')
+    parser.add_argument('--lang', choices=['c', 'c++'], default='c')
 
-    pprint.pprint(get_include_args(compiler))
+    args = parser.parse_args()
+
+    pprint.pprint(get_include_args(cpath=args.compiler, lang=args.lang))

--- a/src/hawkmoth/util/compiler.py
+++ b/src/hawkmoth/util/compiler.py
@@ -61,7 +61,7 @@ def get_include_args(cpath='clang', lang='c', cc_path=None):
         cpath = cc_path
         logger.warning('get_include_args: `cc_path` argument has been deprecated; use `cpath` instead')  # noqa: E501
 
-    return ['-nostdinc'] + [f'-I{path}' for path in _get_include_paths(cpath, lang)]
+    return ['-nostdinc'] + [f'-isystem{path}' for path in _get_include_paths(cpath, lang)]
 
 if __name__ == '__main__':
     import pprint


### PR DESCRIPTION
I was planning on a release, and ran the test suite on all docker containers again. Fedora Rawhide failed due to warnings in GCC 15 C++ headers. Using `-isystem` instead of `-I` suppresses the warnings.
