### PR TITLE
readme: refer to pyproject.toml instead of setup.cfg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,9 +137,9 @@ Dependencies and their minimum versions:
 - Python 3 Bindings for Clang library 6
 
 There are additional development and testing dependencies recorded in
-`setup.cfg`_.
+`pyproject.toml`_.
 
-.. _setup.cfg: https://github.com/jnikula/hawkmoth/blob/master/setup.cfg
+.. _pyproject.toml: https://github.com/jnikula/hawkmoth/blob/master/pyproject.toml
 
 License
 -------


### PR DESCRIPTION
We've migrated to pyproject.toml a while back.