### PR TITLE
extension: fix parsed file cache lookup with clang args

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -129,10 +129,19 @@ class _AutoBaseDirective(SphinxDirective):
         return num_matches
 
     def __get_docstrings(self, viewlist):
+        filter_filenames = self._get_filenames()
+        filter_clang_args = [self.__get_clang_args()]
+
+        # If filenames is None, we're relying on a previous directive to have
+        # parsed the file. In that case, only filter by clang arguments if
+        # they're explicitly specified.
+        if filter_filenames is None and 'clang' not in self.options:
+            filter_clang_args = None
+
         num_matches = 0
-        for root in self.__parsed_files(filter_filenames=self._get_filenames(),
+        for root in self.__parsed_files(filter_filenames=filter_filenames,
                                         filter_domains=[self._domain],
-                                        filter_clang_args=[self.__get_clang_args()]):
+                                        filter_clang_args=filter_clang_args):
             num_matches += self.__get_docstrings_for_root(viewlist, root)
 
         if num_matches == 0:

--- a/test/c/caching.yaml
+++ b/test/c/caching.yaml
@@ -17,5 +17,4 @@ directives:
   - foo_struct
   options:
     members:
-expected-failure: true
 expected: autostruct.rst

--- a/test/c/caching.yaml
+++ b/test/c/caching.yaml
@@ -1,0 +1,21 @@
+directives:
+- domain: c
+  directive: autostruct
+  arguments:
+  - sample_struct
+  options:
+    file: struct.c
+    clang:
+    - -DRANDOM_CLANG_ARG
+    members:
+    - array_member
+    - function_pointer_member
+    - other_function_pointer_member
+- domain: c
+  directive: autostruct
+  arguments:
+  - foo_struct
+  options:
+    members:
+expected-failure: true
+expected: autostruct.rst

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -91,6 +91,12 @@ class ParserTestcase(testenv.Testcase):
             filter_domains = [directive.domain]
             filter_clang_args = [directive.get_clang_args()]
 
+            # If filenames is None, we're relying on a previous directive to have
+            # parsed the file. In that case, only filter by clang arguments if
+            # they're explicitly specified.
+            if filter_filenames is None and 'clang' not in directive.options:
+                filter_clang_args = None
+
             for root in roots.values():
                 if filter_filenames is not None and root.get_filename() not in filter_filenames:
                     continue


### PR DESCRIPTION
We look up parsed results based on both filename and clang args. But if we haven't specified the filename, there's no point in using clang args to filter results unless it's explicitly specified.

Previously, this wouldn't work:

```
.. c:autofunction:: func_a
   :file: foo.c
   :clang: -Icustompath

.. c:autofunction:: func_b

```
Because the latter doesn't have matching `:clang:`. Stop requiring it.

Fixes #273