### PR TITLE
Use :any: instead of :ref: for Javadoc cross-references

### DIFF
--- a/src/hawkmoth/ext/javadoc/__init__.py
+++ b/src/hawkmoth/ext/javadoc/__init__.py
@@ -47,7 +47,7 @@ class _handler:
 
         # references to previous anchors
         # FIXME: link title
-        line = re.sub(fr'{OP}ref\s+(?P<ref>\w+)', r':ref:`\g<ref>`', line)
+        line = re.sub(fr'{OP}ref\s+(?P<ref>\w+)', r':any:`\g<ref>`', line)
 
         # FIXME:
         # - copybrief


### PR DESCRIPTION
Javadoc parsing would replace Javadoc `@ref` with RST `:ref:`.  This only points to labels, not C directives.  A decent alternative is to just use `:any:` to point to anything we can find with the right name.