### PR TITLE
doc/tips: describe ad-hoc extensions

### DIFF
--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -75,3 +75,26 @@ source code changes by adding ``--watch <source root>`` option to
 ``sphinx-autobuild``, where ``<source root>`` matches :py:data:`hawkmoth_root`.
 
 .. _sphinx-autobuild: https://github.com/sphinx-doc/sphinx-autobuild
+
+Ad-hoc Sphinx Extension
+-----------------------
+
+If you need access to Sphinx internals to modify the behavior of Hawkmoth, or to
+write your own Sphinx extensions, you can just add ``def setup()`` to your
+``conf.py`` configuration, and it will be loaded as an
+:external+sphinx:confval:`Ad-Hoc Sphinx Extension <extensions>`.
+
+For example:
+
+.. code-block:: python
+   :caption: conf.py
+
+   def _process_docstring(app, lines, transform, options):
+       pass # do something clever here
+
+   def setup(app):
+       app.connect('hawkmoth-process-docstring', _process_docstring)
+
+The ``setup()`` function will grant access to a Sphinx application context
+(:external+sphinx:py:class:`sphinx.application.Sphinx`) and can thus be used to
+adjust Sphinx to your needs.


### PR DESCRIPTION
Add a section to describe how Sphinx supports ad-hoc extensions. That is, you can just define extensions from within your `conf.py` configuration.

[Jani: Minor stylistic changes, improved the example slightly.]

Basically v2 of #282 by @dvdhrm, to get that and #281 closed.