### PR TITLE
Refactor docstring filtering

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -131,8 +131,15 @@ class _AutoBaseDirective(SphinxDirective):
                 continue
 
             num_matches += 1
-            for docstr in primary.walk(filter_names=self._get_members()):
-                self.__add_docstring_to_viewlist(viewlist, root, docstr)
+
+            self.__add_docstring_to_viewlist(viewlist, root, primary)
+
+            for member in primary:
+                if self._get_members() is not None and member.get_name() not in self._get_members():
+                    continue
+
+                for ds in member.walk():
+                    self.__add_docstring_to_viewlist(viewlist, root, ds)
 
         return num_matches
 

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -112,19 +112,22 @@ class _AutoBaseDirective(SphinxDirective):
 
         self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
 
-    def __get_docstrings_for_root(self, viewlist, root):
+    def __add_docstring_to_viewlist(self, viewlist, root, ds):
         def process_docstring(lines): self.__process_docstring(lines)
 
+        lines, line_number = ds.get_docstring(process_docstring=process_docstring)
+        for line in lines:
+            # viewlist line numbers are 0-based
+            viewlist.append(line, root.get_filename(), line_number - 1)
+            line_number += 1
+
+    def __get_docstrings_for_root(self, viewlist, root):
         num_matches = 0
         for docstrings in root.walk(recurse=False, filter_types=self._docstring_types,
                                     filter_names=self._get_names()):
             num_matches += 1
             for docstr in docstrings.walk(filter_names=self._get_members()):
-                lines, line_number = docstr.get_docstring(process_docstring=process_docstring)
-                for line in lines:
-                    # viewlist line numbers are 0-based
-                    viewlist.append(line, root.get_filename(), line_number - 1)
-                    line_number += 1
+                self.__add_docstring_to_viewlist(viewlist, root, docstr)
 
         return num_matches
 

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -123,10 +123,15 @@ class _AutoBaseDirective(SphinxDirective):
 
     def __get_docstrings_for_root(self, viewlist, root):
         num_matches = 0
-        for docstrings in root.walk(recurse=False, filter_types=self._docstring_types,
-                                    filter_names=self._get_names()):
+        for primary in root:
+            if self._docstring_types is not None and type(primary) not in self._docstring_types:
+                continue
+
+            if self._get_names() is not None and primary.get_name() not in self._get_names():
+                continue
+
             num_matches += 1
-            for docstr in docstrings.walk(filter_names=self._get_members()):
+            for docstr in primary.walk(filter_names=self._get_members()):
                 self.__add_docstring_to_viewlist(viewlist, root, docstr)
 
         return num_matches

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -86,7 +86,7 @@ class Docstring():
 
         return True
 
-    def walk(self, recurse=True, filter_types=None, filter_names=None):
+    def walk(self, filter_types=None, filter_names=None):
         if self._text:
             yield self
 
@@ -298,7 +298,7 @@ class _CompoundDocstring(Docstring):
     def add_children(self, comments):
         self._children.extend(comments)
 
-    def walk(self, recurse=True, filter_types=None, filter_names=None):
+    def walk(self, filter_types=None, filter_names=None):
         # Note: The filtering is pretty specialized for our use case here. It
         # only filters the immediate children, not this comment, nor
         # grandchildren.
@@ -309,10 +309,7 @@ class _CompoundDocstring(Docstring):
 
         for comment in self:
             if comment._match(filter_types=filter_types, filter_names=filter_names):
-                if recurse:
-                    yield from comment.walk()
-                else:
-                    yield comment
+                yield from comment.walk()
 
 class RootDocstring(_CompoundDocstring):
     def __init__(self, filename=None, domain='c', clang_args=None):

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -78,8 +78,12 @@ class Docstring():
         yield from sorted(self._children, key=lambda c: c.get_line())
 
     def walk(self):
+        # The contents of the parent will always be before children.
         if self._text:
             yield self
+
+        for comment in self:
+            yield from comment.walk()
 
     @staticmethod
     def is_doc(comment):
@@ -288,14 +292,6 @@ class _CompoundDocstring(Docstring):
 
     def add_children(self, comments):
         self._children.extend(comments)
-
-    def walk(self):
-        # The contents of the parent will always be before children.
-        if self._text:
-            yield self
-
-        for comment in self:
-            yield from comment.walk()
 
 class RootDocstring(_CompoundDocstring):
     def __init__(self, filename=None, domain='c', clang_args=None):

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -73,6 +73,10 @@ class Docstring():
         self._nest = nest
         self._children = []
 
+    def __iter__(self):
+        # Sort the children by order of appearance.
+        yield from sorted(self._children, key=lambda c: c.get_line())
+
     def _match(self, filter_types=None, filter_names=None):
         if filter_types is not None and type(self) not in filter_types:
             return False
@@ -303,9 +307,7 @@ class _CompoundDocstring(Docstring):
         if self._text:
             yield self
 
-        # Sort the children by order of appearance. We may add other sort
-        # options later.
-        for comment in sorted(self._children, key=lambda c: c.get_line()):
+        for comment in self:
             if comment._match(filter_types=filter_types, filter_names=filter_names):
                 if recurse:
                     yield from comment.walk()

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -77,13 +77,7 @@ class Docstring():
         # Sort the children by order of appearance.
         yield from sorted(self._children, key=lambda c: c.get_line())
 
-    def _match(self, filter_names=None):
-        if filter_names is not None and self.get_name() not in filter_names:
-            return False
-
-        return True
-
-    def walk(self, filter_names=None):
+    def walk(self):
         if self._text:
             yield self
 
@@ -295,18 +289,13 @@ class _CompoundDocstring(Docstring):
     def add_children(self, comments):
         self._children.extend(comments)
 
-    def walk(self, filter_names=None):
-        # Note: The filtering is pretty specialized for our use case here. It
-        # only filters the immediate children, not this comment, nor
-        # grandchildren.
-
+    def walk(self):
         # The contents of the parent will always be before children.
         if self._text:
             yield self
 
         for comment in self:
-            if comment._match(filter_names=filter_names):
-                yield from comment.walk()
+            yield from comment.walk()
 
 class RootDocstring(_CompoundDocstring):
     def __init__(self, filename=None, domain='c', clang_args=None):

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -77,16 +77,13 @@ class Docstring():
         # Sort the children by order of appearance.
         yield from sorted(self._children, key=lambda c: c.get_line())
 
-    def _match(self, filter_types=None, filter_names=None):
-        if filter_types is not None and type(self) not in filter_types:
-            return False
-
+    def _match(self, filter_names=None):
         if filter_names is not None and self.get_name() not in filter_names:
             return False
 
         return True
 
-    def walk(self, filter_types=None, filter_names=None):
+    def walk(self, filter_names=None):
         if self._text:
             yield self
 
@@ -298,7 +295,7 @@ class _CompoundDocstring(Docstring):
     def add_children(self, comments):
         self._children.extend(comments)
 
-    def walk(self, filter_types=None, filter_names=None):
+    def walk(self, filter_names=None):
         # Note: The filtering is pretty specialized for our use case here. It
         # only filters the immediate children, not this comment, nor
         # grandchildren.
@@ -308,7 +305,7 @@ class _CompoundDocstring(Docstring):
             yield self
 
         for comment in self:
-            if comment._match(filter_types=filter_types, filter_names=filter_names):
+            if comment._match(filter_names=filter_names):
                 yield from comment.walk()
 
 class RootDocstring(_CompoundDocstring):

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -97,6 +97,13 @@ class ParserTestcase(testenv.Testcase):
             if filter_filenames is None and 'clang' not in directive.options:
                 filter_clang_args = None
 
+            def get_docstring(ds):
+                transform = directive.options.get('transform')
+                def process_docstring(lines): return _process_docstring(transform, lines)
+
+                lines, _ = ds.get_docstring(process_docstring=process_docstring)
+                return '\n'.join(lines) + '\n'
+
             for root in roots.values():
                 if filter_filenames is not None and root.get_filename() not in filter_filenames:
                     continue
@@ -107,14 +114,10 @@ class ParserTestcase(testenv.Testcase):
                 if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
                     continue
 
-                transform = directive.options.get('transform')
-                def process_docstring(lines): return _process_docstring(transform, lines)
-
                 for docstrings in root.walk(recurse=False, filter_types=_filter_types(directive),
                                             filter_names=_filter_names(directive)):
                     for docstr in docstrings.walk(filter_names=_filter_members(directive)):
-                        lines, _ = docstr.get_docstring(process_docstring=process_docstring)
-                        docs_str += '\n'.join(lines) + '\n'
+                        docs_str += get_docstring(docstr)
 
         return docs_str, errors_str
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -114,9 +114,14 @@ class ParserTestcase(testenv.Testcase):
                 if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
                     continue
 
-                for docstrings in root.walk(recurse=False, filter_types=_filter_types(directive),
-                                            filter_names=_filter_names(directive)):
-                    for docstr in docstrings.walk(filter_names=_filter_members(directive)):
+                for primary in root:
+                    if _filter_types(directive) is not None and type(primary) not in _filter_types(directive):  # noqa: E501
+                        continue
+
+                    if _filter_names(directive) is not None and primary.get_name() not in _filter_names(directive):  # noqa: E501
+                        continue
+
+                    for docstr in primary.walk(filter_names=_filter_members(directive)):
                         docs_str += get_docstring(docstr)
 
         return docs_str, errors_str

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -121,8 +121,14 @@ class ParserTestcase(testenv.Testcase):
                     if _filter_names(directive) is not None and primary.get_name() not in _filter_names(directive):  # noqa: E501
                         continue
 
-                    for docstr in primary.walk(filter_names=_filter_members(directive)):
-                        docs_str += get_docstring(docstr)
+                    docs_str += get_docstring(primary)
+
+                    for member in primary:
+                        if _filter_members(directive) is not None and member.get_name() not in _filter_members(directive):  # noqa: E501
+                            continue
+
+                        for ds in member.walk():
+                            docs_str += get_docstring(ds)
 
         return docs_str, errors_str
 


### PR DESCRIPTION
The filtering in `Docstring.walk()` has always been cumbersome at best, as described by the comment:

```
        # Note: The filtering is pretty specialized for our use case here. It
        # only filters the immediate children, not this comment, nor
        # grandchildren.
```

Refactor all of the filtering out of `Docstring` to the calling side, which has a much better idea what and how to filter. The division of responsibilities is better, and `Docstring` becomes more clear.

Initially, the filtering on the calling side (the extension and parser test) is 1:1 to the original, and further cleanups are left for the future. Also, this should make fancier filtering such as  #284 easier to implement cleanly.
