### PR TITLE
Refactor docstring processing

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -110,13 +110,17 @@ class _AutoBaseDirective(SphinxDirective):
             viewlist.append(line, root.get_filename(), line_number - 1)
             line_number += 1
 
+    @staticmethod
+    def _skip(thing, iterable):
+        return iterable is not None and thing not in iterable
+
     def __get_docstrings_for_root(self, viewlist, root):
         num_matches = 0
         for primary in root:
-            if self._docstring_types is not None and type(primary) not in self._docstring_types:
+            if self._skip(type(primary), self._docstring_types):
                 continue
 
-            if self._get_names() is not None and primary.get_name() not in self._get_names():
+            if self._skip(primary.get_name(), self._get_names()):
                 continue
 
             num_matches += 1
@@ -124,7 +128,7 @@ class _AutoBaseDirective(SphinxDirective):
             self.__add_docstring_to_viewlist(viewlist, root, primary)
 
             for member in primary:
-                if self._get_members() is not None and member.get_name() not in self._get_members():
+                if self._skip(member.get_name(), self._get_members()):
                     continue
 
                 for ds in member.walk():
@@ -145,13 +149,13 @@ class _AutoBaseDirective(SphinxDirective):
 
         num_matches = 0
         for root in self.__parsed_files():
-            if filter_filenames is not None and root.get_filename() not in filter_filenames:
+            if self._skip(root.get_filename(), filter_filenames):
                 continue
 
-            if filter_domains is not None and root.get_domain() not in filter_domains:
+            if self._skip(root.get_domain(), filter_domains):
                 continue
 
-            if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
+            if self._skip(root.get_clang_args(), filter_clang_args):
                 continue
 
             num_matches += self.__get_docstrings_for_root(viewlist, root)

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -134,7 +134,9 @@ class _AutoBaseDirective(SphinxDirective, docstring.DocstringProcessor):
 
         return num_matches
 
-    def __get_docstrings(self, viewlist):
+    def __get_docstrings(self):
+        viewlist = ViewList()
+
         filter_filenames = self._get_filenames()
         filter_domains = [self._domain]
         filter_clang_args = [self.__get_clang_args()]
@@ -172,6 +174,8 @@ class _AutoBaseDirective(SphinxDirective, docstring.DocstringProcessor):
             self.logger.warning(f'"{self.name}:: {args}" matches {num_matches} documented symbols.',
                                 location=(self.env.docname, self.lineno))
 
+        return viewlist
+
     def _get_names(self):
         return None
 
@@ -186,9 +190,7 @@ class _AutoBaseDirective(SphinxDirective, docstring.DocstringProcessor):
             for filename in self._get_filenames():
                 self.__parse(filename)
 
-        result = ViewList()
-
-        self.__get_docstrings(result)
+        result = self.__get_docstrings()
 
         # Parse the extracted reST
         with switch_source_input(self.state, result):

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -91,21 +91,10 @@ class _AutoBaseDirective(SphinxDirective):
 
         parsed_files[key] = docstrings
 
-    def __parsed_files(self, filter_filenames=None, filter_domains=None,
-                       filter_clang_args=None):
+    def __parsed_files(self):
         parsed_files = self.env.temp_data.get('hawkmoth_parsed_files', {})
 
-        for root in parsed_files.values():
-            if filter_filenames is not None and root.get_filename() not in filter_filenames:
-                continue
-
-            if filter_domains is not None and root.get_domain() not in filter_domains:
-                continue
-
-            if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
-                continue
-
-            yield root
+        return parsed_files.values()
 
     def __process_docstring(self, lines):
         transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
@@ -145,6 +134,7 @@ class _AutoBaseDirective(SphinxDirective):
 
     def __get_docstrings(self, viewlist):
         filter_filenames = self._get_filenames()
+        filter_domains = [self._domain]
         filter_clang_args = [self.__get_clang_args()]
 
         # If filenames is None, we're relying on a previous directive to have
@@ -154,9 +144,16 @@ class _AutoBaseDirective(SphinxDirective):
             filter_clang_args = None
 
         num_matches = 0
-        for root in self.__parsed_files(filter_filenames=filter_filenames,
-                                        filter_domains=[self._domain],
-                                        filter_clang_args=filter_clang_args):
+        for root in self.__parsed_files():
+            if filter_filenames is not None and root.get_filename() not in filter_filenames:
+                continue
+
+            if filter_domains is not None and root.get_domain() not in filter_domains:
+                continue
+
+            if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
+                continue
+
             num_matches += self.__get_docstrings_for_root(viewlist, root)
 
         if num_matches == 0:

--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -29,7 +29,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)),
                        'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
-class _AutoBaseDirective(SphinxDirective):
+class _AutoBaseDirective(SphinxDirective, docstring.DocstringProcessor):
     logger = logging.getLogger(__name__)
 
     option_spec = {
@@ -96,15 +96,13 @@ class _AutoBaseDirective(SphinxDirective):
 
         return parsed_files.values()
 
-    def __process_docstring(self, lines):
+    def process_docstring(self, lines):
         transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
 
         self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
 
     def __add_docstring_to_viewlist(self, viewlist, root, ds):
-        def process_docstring(lines): self.__process_docstring(lines)
-
-        lines, line_number = ds.get_docstring(process_docstring=process_docstring)
+        lines, line_number = ds.get_docstring(processor=self)
         for line in lines:
             # viewlist line numbers are 0-based
             viewlist.append(line, root.get_filename(), line_number - 1)

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -141,16 +141,13 @@ class Docstring():
         """
         lines[:] = ['   ' * nest + line if line else '' for line in lines]
 
-    def get_docstring(self, process_docstring=None, processor=None):
+    def get_docstring(self, processor):
         header_lines = self._get_header_lines()
         comment_lines = self._get_comment_lines()
 
         line_offset = Docstring._remove_comment_markers(comment_lines)
 
-        if process_docstring is not None:
-            process_docstring(comment_lines)
-        elif processor is not None:
-            processor.process_docstring(comment_lines)
+        processor.process_docstring(comment_lines)
 
         Docstring._nest_lines(comment_lines, self._indent)
 

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -88,7 +88,7 @@ class Docstring():
     _indent = 0
     _fmt = ''
 
-    def __init__(self, cursor=None, text=None, meta=None, nest=0):
+    def __init__(self, cursor, nest):
         if cursor:
             self._args = cursor.args
             self._decl_name = cursor.decl_name
@@ -102,10 +102,10 @@ class Docstring():
             self._args = None
             self._decl_name = None
             self._domain = None
-            self._meta = meta
+            self._meta = None
             self._name = None
             self._quals = None
-            self._text = text
+            self._text = None
             self._ttype = None
 
         self._nest = nest
@@ -184,6 +184,11 @@ class Docstring():
 class TextDocstring(Docstring):
     _indent = 0
     _fmt = ''
+
+    def __init__(self, text, meta):
+        super().__init__(cursor=None, nest=0)
+        self._text = text
+        self._meta = meta
 
     def get_name(self):
         """Figure out a name for the text comment based on the comment contents.
@@ -295,8 +300,8 @@ class _CompoundDocstring(Docstring):
         self._children.extend(comments)
 
 class RootDocstring(_CompoundDocstring):
-    def __init__(self, filename=None, domain='c', clang_args=None):
-        super().__init__()
+    def __init__(self, filename, domain, clang_args):
+        super().__init__(cursor=None, nest=0)
         self._filename = filename
         self._domain = domain
         self._clang_args = clang_args
@@ -326,7 +331,7 @@ class EnumeratorDocstring(Docstring):
     _indent = 1
     _fmt = '.. {domain}:enumerator:: {name}{value}'
 
-    def __init__(self, cursor, nest=0):
+    def __init__(self, cursor, nest):
         self._value = cursor.value
         super().__init__(cursor=cursor, nest=nest)
 

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -46,6 +46,10 @@ def _get_prefix_len(lines):
 
     return prefix_len
 
+class DocstringProcessor():
+    def process_docstring(self, lines):
+        pass
+
 class Docstring():
     _indent = 0
     _fmt = ''
@@ -137,7 +141,7 @@ class Docstring():
         """
         lines[:] = ['   ' * nest + line if line else '' for line in lines]
 
-    def get_docstring(self, process_docstring=None):
+    def get_docstring(self, process_docstring=None, processor=None):
         header_lines = self._get_header_lines()
         comment_lines = self._get_comment_lines()
 
@@ -145,6 +149,8 @@ class Docstring():
 
         if process_docstring is not None:
             process_docstring(comment_lines)
+        elif processor is not None:
+            processor.process_docstring(comment_lines)
 
         Docstring._nest_lines(comment_lines, self._indent)
 

--- a/src/hawkmoth/docstring.py
+++ b/src/hawkmoth/docstring.py
@@ -72,6 +72,18 @@ class DocstringProcessor():
 
         return line_offset
 
+    def nest_lines(self, lines, nest):
+        """
+        Indent documentation block for nesting.
+
+        Args:
+            lines (List[str]): Documentation body as list of strings,
+                modified in-place.
+            nest (int): Nesting level. For each level, the final block is indented
+                one level. Useful for (e.g.) declaring structure members.
+        """
+        lines[:] = ['   ' * nest + line if line else '' for line in lines]
+
 class Docstring():
     _indent = 0
     _fmt = ''
@@ -127,19 +139,6 @@ class Docstring():
     def _get_comment_lines(self):
         return statemachine.string2lines(self._text, 8, convert_whitespace=True)
 
-    @staticmethod
-    def _nest_lines(lines, nest):
-        """
-        Indent documentation block for nesting.
-
-        Args:
-            lines (List[str]): Documentation body as list of strings,
-                modified in-place.
-            nest (int): Nesting level. For each level, the final block is indented
-                one level. Useful for (e.g.) declaring structure members.
-        """
-        lines[:] = ['   ' * nest + line if line else '' for line in lines]
-
     def get_docstring(self, processor):
         header_lines = self._get_header_lines()
         comment_lines = self._get_comment_lines()
@@ -148,7 +147,7 @@ class Docstring():
 
         processor.process_docstring(comment_lines)
 
-        Docstring._nest_lines(comment_lines, self._indent)
+        processor.nest_lines(comment_lines, self._indent)
 
         # ensure we have cushion blank line before the docstring
         if len(header_lines) == 0 or header_lines[0] != '':
@@ -162,7 +161,7 @@ class Docstring():
 
         lines = header_lines + comment_lines
 
-        Docstring._nest_lines(lines, self._nest)
+        processor.nest_lines(lines, self._nest)
 
         # ensure we have cushion blank line after the docstring
         if lines[-1] != '':

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -104,27 +104,30 @@ class ParserTestcase(testenv.Testcase):
                 lines, _ = ds.get_docstring(process_docstring=process_docstring)
                 return '\n'.join(lines) + '\n'
 
+            def skip(thing, iterable):
+                return iterable is not None and thing not in iterable
+
             for root in roots.values():
-                if filter_filenames is not None and root.get_filename() not in filter_filenames:
+                if skip(root.get_filename(), filter_filenames):
                     continue
 
-                if filter_domains is not None and root.get_domain() not in filter_domains:
+                if skip(root.get_domain(), filter_domains):
                     continue
 
-                if filter_clang_args is not None and root.get_clang_args() not in filter_clang_args:
+                if skip(root.get_clang_args(), filter_clang_args):
                     continue
 
                 for primary in root:
-                    if _filter_types(directive) is not None and type(primary) not in _filter_types(directive):  # noqa: E501
+                    if skip(type(primary), _filter_types(directive)):
                         continue
 
-                    if _filter_names(directive) is not None and primary.get_name() not in _filter_names(directive):  # noqa: E501
+                    if skip(primary.get_name(), _filter_names(directive)):
                         continue
 
                     docs_str += get_docstring(primary)
 
                     for member in primary:
-                        if _filter_members(directive) is not None and member.get_name() not in _filter_members(directive):  # noqa: E501
+                        if skip(member.get_name(), _filter_members(directive)):
                             continue
 
                         for ds in member.walk():


### PR DESCRIPTION
Follow-up to #287 with a bunch more refactoring.

The primary change is adding a `DocstringProcessor` class for, well, processing docstrings, instead of passing in functions that require lambdas in the callers.

While no new Sphinx events are added here, this makes it much easier to add events that you could pass the `DocCursor` and `header_lines` to.