### PR TITLE
github: keep running macOS CI on macos-14

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -82,7 +82,7 @@ jobs:
 
   test-macos-homebrew:
     name: Run test suite (macOS homebrew)
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
macos-latest has recently been bumped from macos-14 to macos-15. This breaks our CI. As a stopgap measure, stick to macos-15.

See https://github.com/actions/runner-images/issues/12520