### PR TITLE
extension: fix env.app deprecation warning

### DIFF
--- a/src/hawkmoth/__init__.py
+++ b/src/hawkmoth/__init__.py
@@ -100,7 +100,7 @@ class _AutoBaseDirective(SphinxDirective, docstring.DocstringProcessor):
     def process_docstring(self, lines):
         transform = self.options.get('transform', self.env.config.hawkmoth_transform_default)
 
-        self.env.app.emit('hawkmoth-process-docstring', lines, transform, self.options)
+        self.env.events.emit('hawkmoth-process-docstring', lines, transform, self.options)
 
     def __add_docstring_to_viewlist(self, viewlist, root, ds):
         lines, line_number = ds.get_docstring(processor=self)


### PR DESCRIPTION
Switch from env.app.emit() to env.events.emit() to fix the Sphinx deprecation warning introduced in version v9.0.0:

RemovedInSphinx11Warning: 'sphinx.environment.BuildEnvironment.app' is deprecated

The env.events.emit() interface has been there since Sphinx v3.0.0, so there shouldn't be any need to bump dependencies for this.

See also https://github.com/sphinx-doc/sphinx/issues/14119